### PR TITLE
Compile daemon as Position Independent Executable

### DIFF
--- a/Main/GNUmakefile
+++ b/Main/GNUmakefile
@@ -4,9 +4,10 @@ include ../config.make
 include $(GNUSTEP_MAKEFILES)/common.make
 include ../Version
 
-ADDITIONAL_INCLUDE_DIRS += 
+ADDITIONAL_OBJCFLAGS += -fPIE
+ADDITIONAL_INCLUDE_DIRS +=
 ADDITIONAL_LIB_DIRS += -L../SOPE/GDLContentStore/obj/
-ADDITIONAL_LDFLAGS += -Wl,--no-as-needed
+ADDITIONAL_LDFLAGS += -Wl,--no-as-needed -fPIE -pie
 
 SOGOD     = sogod
 TOOL_NAME = $(SOGOD)


### PR DESCRIPTION
This makes it possible to use ASLR and as such provides extra security. Almost everything in SOGo is compiled as a shared library anyway, making the small part that is left also position independent shouldn't give anyway problem. Support -fPIE was added in gcc 3.4 so it should be supported on all current platforms.
