### PR TITLE
Read configuration from /etc/sogo/sogo.conf

### DIFF
--- a/Tools/sogo-tool.m
+++ b/Tools/sogo-tool.m
@@ -221,8 +221,14 @@ static void
 setupUserDefaults (NSUserDefaults *ud)
 {
   NSMutableDictionary *defaultsOverrides;
+  NSDictionary *domain;
 
-  [ud registerDefaults: [ud persistentDomainForName: @"sogod"]];
+  domain = [ud persistentDomainForName: @"sogod"];
+  if (![domain count])
+    {
+      domain = [ud volatileDomainForName: @"sogod"];
+    }
+  [ud registerDefaults: domain];
   defaultsOverrides = [NSMutableDictionary new];
   [defaultsOverrides setObject: [NSNumber numberWithInt: 0]
                         forKey: @"SOGoLDAPQueryLimit"];


### PR DESCRIPTION
This reads the configuration from /etc/sogo/sogo.conf. It also reads configuration from /etc/sogo/debconf.conf (which isn't used yet in the Debian package, but I want to in the future). I'm not totally fond of that solution and this isn't suitable to be merged. Maybe we should make it possible to specify configuration files on the command line, so I could specify the debconf file in the init script.
