### PR TITLE
Create a real system account for sogo.

### DIFF
--- a/packaging/rhel/sogo.spec
+++ b/packaging/rhel/sogo.spec
@@ -300,7 +300,11 @@ rm -fr ${RPM_BUILD_ROOT}
 
 # **************************** pkgscripts *****************************
 %post
-if ! id sogo >& /dev/null; then /usr/sbin/useradd -m -k /var/empty -r sogo > /dev/null 2>&1; fi
+if ! id sogo >& /dev/null; then 
+	/usr/sbin/useradd -c "SOGo system user" -d /var/sogo -r -s /sbin/nologin sogo > /dev/null 2>&1; 
+	mkdir -p /var/sogo
+	/bin/chown sogo /var/sogo
+fi
 /bin/chown sogo /var/run/sogo
 /bin/chown sogo /var/log/sogo
 /bin/chown sogo /var/spool/sogo


### PR DESCRIPTION
Ref: commit ac5c2b611a5486917427a9faf4fe285a209625ff which intends to fix bug #1470. IMHO a system account should not be available for interactive usage, and also not reside together with the user accounts in /home (which often is a remote filesystem (NFS)). Also this commit copies several opensshd-files that lives under /var/empty/sshd to /home/sogo, which clearly was not intended..

Please consider this commit to create a _real_ system account, with empty home directory in /var/sogo, and /sbin/nologin for shell.
