### PR TITLE
Link libSOGo with libdl on systems with glibc

### DIFF
--- a/SoObjects/SOGo/GNUmakefile.preamble
+++ b/SoObjects/SOGo/GNUmakefile.preamble
@@ -49,6 +49,10 @@ else
 SOGo_LIBRARIES_DEPEND_UPON += -lcrypt
 endif
 
+ifeq ($(findstring gnu, $(GNUSTEP_HOST_OS)), gnu)
+SOGo_LIBRARIES_DEPEND_UPON += -ldl
+endif
+
 ADDITIONAL_TOOL_LIBS += \
         -L$(GNUSTEP_OBJ_DIR)/ \
         -lSOGo \


### PR DESCRIPTION
This one somehow went missing when my patch was merged. Glibc puts the dl_\* functions in libdl and we shoud link with libdl on glibc-based systems. The check for gnu instead of for linux means it also works on non-linux glibc systems such as Debian GNU/kFreebsd.
