### PR TITLE
Allow fallback if proxy did not authenticate user, and trusted proxy auth set

### DIFF
--- a/Apache/SOGo.conf
+++ b/Apache/SOGo.conf
@@ -26,7 +26,18 @@ Alias /SOGo/WebServerResources/ \
 ## need to set the "SOGoTrustProxyAuthentication" SOGo user default to YES and
 ## adjust the "x-webobjects-remote-user" proxy header in the "Proxy" section
 ## below.
+#
+## For full proxy-side authentication:
 #<Location /SOGo>
+#  AuthType XXX
+#  Require valid-user
+#  SetEnv proxy-nokeepalive 1
+#  Allow from all
+#</Location>
+#
+## For proxy-side authentication only for CardDAV and GroupDAV from external
+## clients:
+#<Location /SOGo/dav>
 #  AuthType XXX
 #  Require valid-user
 #  SetEnv proxy-nokeepalive 1
@@ -64,7 +75,8 @@ ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0
 
 ## When using proxy-side autentication, you need to uncomment and
 ## adjust the following line:
-#  RequestHeader set "x-webobjects-remote-user" "%{REMOTE_USER}e"
+  RequestHeader unset "x-webobjects-remote-user"
+#  RequestHeader set "x-webobjects-remote-user" "%{REMOTE_USER}e" env=REMOTE_USER
 
   RequestHeader set "x-webobjects-server-protocol" "HTTP/1.0"
 

--- a/Main/SOGo.m
+++ b/Main/SOGo.m
@@ -283,7 +283,7 @@ static BOOL debugLeaks;
 {
   id authenticator;
 
-  if (trustProxyAuthentication)
+  if (trustProxyAuthentication && [[context request] headerForKey: @"x-webobjects-remote-user"])
     authenticator = [SOGoProxyAuthenticator sharedSOGoProxyAuthenticator];
   else
     {


### PR DESCRIPTION
If trusted proxy authentication is on, yet the proxy did not authenticate the user, then the default authentication method is used instead of returning 'Unauthorized'. This is useful primarily in the case of single sign-on for CardDAV and GroupDAV for external clients, but still requiring the use of a password for webmail so that IMAP and SMTP can still authenticate properly.
