### PR TITLE
Prevent crash when asking a REPORT on (probably amongst others) a contact folder

### DIFF
--- a/SoObjects/Contacts/SOGoContactSourceFolder.m
+++ b/SoObjects/Contacts/SOGoContactSourceFolder.m
@@ -560,6 +560,7 @@
 {
   NSObject <DOMElement> *element;
   NSString *url, *baseURL, *cname;
+  NSDictionary *object;
   NSString **propertiesArray;
   NSMutableString *buffer;
   unsigned int count, max, propertiesCount;
@@ -580,8 +581,9 @@
       element = [refs objectAtIndex: count];
       url = [[[element firstChild] nodeValue] stringByUnescapingURL];
       cname = [self _deduceObjectNameFromURL: url fromBaseURL: baseURL];
-      if (cname)
-        [self appendObject: [source lookupContactEntry: cname]
+      object = [source lookupContactEntry: cname];
+      if (cname && object)
+        [self appendObject: object
                 properties: propertiesArray
                      count: propertiesCount
                withBaseURL: baseURL


### PR DESCRIPTION
This happens when a client also asks a REPORT for the contact folder as for the entries in it. From the logs:
EXCEPTION: <NSException: 0x7f964a245c70> NAME:NSInvalidArgumentException REASON:'_name' must not be an empty string INFO:(null)
Oct 31 12:40:25 sogod [33810]: <0x0x7f9649d30980[WOWatchDogChild]> child 33879 exited
Oct 31 12:40:25 sogod [33810]: <0x0x7f9649d30980[WOWatchDogChild]>  (terminated due to signal 6)

This occurs especially using clients (2 Android clients tested) that use draft-murchison-webdav-prefer-05 for the noroot hint instead of the microsoft extension implemented by sope (may be a patch coming up). So they also get the information of the root, expecting something to be there as the server gives this entry also as a reply.
