### PR TITLE
Fix #2641

### DIFF
--- a/UI/WebServerResources/UIxMailEditor.js
+++ b/UI/WebServerResources/UIxMailEditor.js
@@ -417,6 +417,7 @@ function configureAttachments() {
             // With singleFileUploads option enabled, the 'add' and 'done' (or 'fail') callbacks
             // are called once for each file in the selection for XHR file uploads
             singleFileUploads: true,
+            pasteZone: null,
             dataType: 'json',
             add: function (e, data) {
                 var file = data.files[0];


### PR DESCRIPTION
Disabling the pasteZone support (which only works in Chrome or Opera anyway) fixes the problem of unwanted PNG attachment when you paste the recipient list from Excel
