### PR TITLE
ModulesConstraints tests all values of a multi-valued attributes

### DIFF
--- a/SoObjects/SOGo/LDAPSource.m
+++ b/SoObjects/SOGo/LDAPSource.m
@@ -887,7 +887,7 @@ static Class NSStringK;
            intoLDIFRecord: (NSMutableDictionary *) ldifRecord
 {
   NSDictionary *constraints;
-  NSEnumerator *matches;
+  NSEnumerator *matches, *ldapValues;
   NSString *currentMatch, *currentValue, *ldapValue;
   BOOL result;
 
@@ -897,16 +897,15 @@ static Class NSStringK;
   if (constraints)
     {
       matches = [[constraints allKeys] objectEnumerator];
-      currentMatch = [matches nextObject];
-      while (result && currentMatch)
+      while (result == YES && (currentMatch = [matches nextObject]))
         {
-          ldapValue = [[ldapEntry attributeWithName: currentMatch]
-            stringValueAtIndex: 0];
+          ldapValues = [[[ldapEntry attributeWithName: currentMatch] allStringValues] objectEnumerator];
           currentValue = [constraints objectForKey: currentMatch];
-          if ([ldapValue caseInsensitiveMatches: currentValue])
-            currentMatch = [matches nextObject];
-          else
-            result = NO;
+          result = NO;
+
+          while (result == NO && (ldapValue = [ldapValues nextObject]))
+            if ([ldapValue caseInsensitiveMatches: currentValue])
+              result = YES;
         }
     }
 


### PR DESCRIPTION
ModulesConstraints tests all values of a multi-valued attributes (instead of just the first one). Thus the following now works:

```
ModulesConstraints = {
    Mail = {
        memberOf = "cn=aclSogoMail,ou=Groups,dc=example,dc=com";
    };
    Calendar = {
        memberOf = "cn=aclSogoCalendar,ou=Groups,dc=example,dc=com";
    };
};
```

Assuming a user entry in LDAP looks like the following:

```
dn: uid=bro,ou=Peolpe,dc=example,dc=com
memberOf: cn=aclSsh,ou=Groups,dc=example,dc=com
memberOf: cn=aclSogoCalendar,ou=Groups,dc=example,dc=com
```

... bro can only access the SOGo calendar, but not the mail module.
