### PR TITLE
Fix email validation regexp to allow gTLDs

### DIFF
--- a/UI/WebServerResources/generic.js
+++ b/UI/WebServerResources/generic.js
@@ -45,7 +45,7 @@ var activeAjaxRequests = 0;
 var removeFolderRequestCount = 0;
 
 // Email validation regexp
-var emailRE = /^([\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+\.)*[\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+@((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,6})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)$/i;
+var emailRE = /^([\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+\.)*[\w\!\#$\%\&\'\*\+\-\/\=\?\^\`{\|\}\~]+@((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)$/i;
 
 
 /* This function enables the execution of a wrapper function just before the


### PR DESCRIPTION
New generic TLDs can be as long as 13 characters.
