### PR TITLE
Delete generated source files when running "make clean".

### DIFF
--- a/OpenChange/GNUmakefile.preamble
+++ b/OpenChange/GNUmakefile.preamble
@@ -3,3 +3,6 @@ all:: MAPIStorePropertySelectors.m MAPIStorePropertySelectors.h
 MAPIStorePropertySelectors.m MAPIStorePropertySelectors.h: gen-property-selectors.py code-MAPIStorePropertySelectors.m code-MAPIStorePropertySelectors.h
 	@echo " Auto-generating MAPIStorePropertySelectors.[hm]..."
 	@$(PYTHON) ./gen-property-selectors.py -o MAPIStorePropertySelectors $(LIBMAPISTORE_CFLAGS)
+
+distclean clean::
+	-rm -f MAPIStorePropertySelectors.m MAPIStorePropertySelectors.h

--- a/SoObjects/SOGo/GNUmakefile
+++ b/SoObjects/SOGo/GNUmakefile
@@ -158,6 +158,9 @@ ifeq ($(saml2_config), yes)
 SOGoSAML2Exceptions.h SOGoSAML2Exceptions.m: gen-saml2-exceptions.py
 	$(ECHO_CREATING) ./gen-saml2-exceptions.py $(LASSO_CFLAGS) $(END_ECHO)
 
+distclean clean::
+	-rm -f SOGoSAML2Exceptions.h SOGoSAML2Exceptions.m
+
 endif
 
 ifeq ($(ldap_config),yes)


### PR DESCRIPTION
We should delete the source files that are generated when "make clean" is run.
