### PR TITLE
Link correctly against libraries used

### DIFF
--- a/OpenChange/GNUmakefile
+++ b/OpenChange/GNUmakefile
@@ -171,7 +171,7 @@ LIBMAPISTORE_LIBS = $(shell pkg-config libmapistore --libs) -lmapiproxy -lWEExte
 
 $(MAPISTORESOGO)_INSTALL_DIR = $(DESTDIR)/$(SAMBA_LIB_DIR)/mapistore_backends
 $(MAPISTORESOGO)_LIB_DIRS += \
-        -L../SoObjects/SOGo/SOGo.framework/ -lSOGo \
+        -L../SoObjects/SOGo/SOGo.framework/ -lSOGo -lgnustep-base -lobjc -lNGObjWeb \
 	$(LIBMAPI_LIBS) \
 	$(LIBMAPISTORE_LIBS)
 

--- a/configure
+++ b/configure
@@ -381,7 +381,7 @@ checkDependencies() {
       if test $? = 0; then
           lasso_cflags="`pkg-config lasso --cflags`"
           cfgwrite "LASSO_CFLAGS := $lasso_cflags"
-          lasso_libs="`pkg-config lasso --libs`"
+          lasso_libs="`pkg-config lasso --libs` `pkg-config gobject-2.0 --libs`"
           cfgwrite "LASSO_LIBS := $lasso_libs"
       fi;
   fi


### PR DESCRIPTION
The mapistore backend uses libgnustep-base, libobjc, libNGObjWeb, but wasn't linked against to libraries. The SAML code has a few calls to gobject functions, so use pkg-config in configure to link to gobject-2.0. This makes it possible for dpkg-shlibdeps to calculate the correct library packages to depend on and will also make sure that ABI changes using symbol versioning will work correctly.

P.S. Pull request #10 that fixes a similar issue is also still open.
