### PR TITLE
Minor documentation issues and missing IMAP pooling option description

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1632,6 +1632,12 @@ cronjob `sogo-tmpwatch`.
 
 Defaults to `/var/spool/sogo`.
 
+|S |NGImap4DisableIMAP4Pooling
+|Disables IMAP pooling when set to `YES`. Enable pooling by setting to
+`NO` or using a caching proxy like imapproxy.
+
+The default value is `YES`.
+
 |S |NGImap4ConnectionStringSeparator
 |Parameter used to set the IMAP mailbox separator. Setting this will
 also have an impact on the mailbox separator used by Sieve filters.


### PR DESCRIPTION
- The minor formatting issues are obvious.
- The option was missing and only described in the changelogs and mailing list up to now. I'm not sure whether I got the scope right, please have a look on this. Server `S` or domain `D`?
