### PR TITLE
Change ACL modification text to non-gender specific terms

### DIFF
--- a/SoObjects/Appointments/SOGoAppointmentObject.m
+++ b/SoObjects/Appointments/SOGoAppointmentObject.m
@@ -443,7 +443,7 @@
           us = [user userSettings];
           moduleSettings = [us objectForKey:@"Calendar"];
           
-          // Check if the user prevented his account from beeing invited to events
+          // Check if the user prevented their account from beeing invited to events
           if (![user isResource] && [[moduleSettings objectForKey:@"PreventInvitations"] boolValue])
             {
               // Check if the user have a whiteList
@@ -1093,7 +1093,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
           else
             {
               // We must REMOVE any SENT-BY here. This is important since if A accepted
-              // the event for B and then, B changes by himself his participation status,
+              // the event for B and then, B changes by theirself their participation status,
               // we don't want to keep the previous SENT-BY attribute there.
               [(NSMutableDictionary *)[otherAttendee attributes] removeObjectForKey: @"SENT-BY"];
             }
@@ -1191,7 +1191,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
       else
         {
           // We must REMOVE any SENT-BY here. This is important since if A accepted
-          // the event for B and then, B changes by himself his participation status,
+          // the event for B and then, B changes by theirself their participation status,
           // we don't want to keep the previous SENT-BY attribute there.
           [(NSMutableDictionary *)[attendee attributes] removeObjectForKey: @"SENT-BY"];
         }
@@ -1208,7 +1208,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
               
               delegatedUID = [otherDelegate uid];
               if (delegatedUID)
-                // Delegate attendee is a local user; remove event from his calendar
+                // Delegate attendee is a local user; remove event from their calendar
                 [self _removeEventFromUID: delegatedUID
                                     owner: [theOwnerUser login]
                          withRecurrenceId: [event recurrenceId]];
@@ -1240,7 +1240,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
           [event addToAttendees: delegate];
           
           if (delegatedUID)
-            // Delegate attendee is a local user; add event to his calendar
+            // Delegate attendee is a local user; add event to their calendar
             [self _addOrUpdateEvent: event
                              forUID: delegatedUID
                               owner: [theOwnerUser login]];

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -644,8 +644,8 @@
   // As much as we can, we try to use c_name == c_uid in order
   // to avoid tricky scenarios with some CalDAV clients. For example,
   // if Alice invites Bob (both use SOGo) and Bob accepts the invitation
-  // using Lightning before having refreshed his calendar, he'll end up
-  // with a duplicate of the event in his database tables.
+  // using Lightning before having refreshed their calendar, they'll end up
+  // with a duplicate of the event in their database tables.
   if (isNew)
     {
       newUid = nameInContainer;

--- a/SoObjects/SOGo/SOGoGCSFolder.m
+++ b/SoObjects/SOGo/SOGoGCSFolder.m
@@ -302,7 +302,7 @@ static NSArray *childRecordFields = nil;
 }
 
 /* This method fetches the display name defined by the owner, but is also the
-   fallback when a subscriber has not redefined the display name yet in his
+   fallback when a subscriber has not redefined the display name yet in their
    environment. */
 - (NSString *) _displayNameFromOwner
 {
@@ -895,7 +895,7 @@ static NSArray *childRecordFields = nil;
       allUsers = [NSMutableArray arrayWithArray: [aGroup members]];
 
       // We remove the active user from the group (if present) in order to
-      // not subscribe him to his own resource!
+      // not subscribe him to their own resource!
       [allUsers removeObject: [context activeUser]];
     }
   else

--- a/SoObjects/SOGo/SOGoUserFolder.h
+++ b/SoObjects/SOGo/SOGoUserFolder.h
@@ -31,7 +31,7 @@
     Child objects: 
       'Calendar': SOGoAppointmentFolder
   
-  The SOGoUserFolder is the "home directory" of the user where all his 
+  The SOGoUserFolder is the "home directory" of the user where all their 
   processing starts. It is the 'znek' in such a path:
     /SOGo/so/znek/Calendar
 */

--- a/UI/MainUI/SOGoRootPage.m
+++ b/UI/MainUI/SOGoRootPage.m
@@ -361,7 +361,7 @@
 
   if (login)
     {
-      /* We redirect the user to his "homepage" when newLocation could not be
+      /* We redirect the user to their "homepage" when newLocation could not be
          deduced from the "cas-location" cookie and the current action is not a
          login callback (ticket != nil).  */
       if (!newLocation || !ticket)

--- a/UI/Templates/SOGoACLDanishModificationAdvisory.wox
+++ b/UI/Templates/SOGoACLDanishModificationAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can subscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>subscribe?mail-invitation=YES

--- a/UI/Templates/SOGoACLDanishRemovalAdvisory.wox
+++ b/UI/Templates/SOGoACLDanishRemovalAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can unsubscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>unsubscribe?mail-invitation=YES

--- a/UI/Templates/SOGoACLDutchModificationAdvisory.wox
+++ b/UI/Templates/SOGoACLDutchModificationAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can subscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>subscribe?mail-invitation=YES

--- a/UI/Templates/SOGoACLDutchRemovalAdvisory.wox
+++ b/UI/Templates/SOGoACLDutchRemovalAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can unsubscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>unsubscribe?mail-invitation=YES

--- a/UI/Templates/SOGoACLEnglishModificationAdvisory.wox
+++ b/UI/Templates/SOGoACLEnglishModificationAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has modified your access rights for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can subscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>subscribe?mail-invitation=YES

--- a/UI/Templates/SOGoACLEnglishRemovalAdvisory.wox
+++ b/UI/Templates/SOGoACLEnglishRemovalAdvisory.wox
@@ -12,7 +12,7 @@
 </var:if>
 
 <var:if condition="isBody">
-<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for his <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
+<var:string value="currentUserName" const:escapeHTML="NO"/> has removed you from the access list for their <var:string const:value='"' const:escapeHTML="NO"/><var:string value="resourceName" const:escapeHTML="NO"/><var:string const:value='"' const:escapeHTML="NO"/> folder.
 <!--
 You can unsubscribe directly to that folder by following this link:
     <var:string value="httpAdvisoryURL" const:escapeHTML="NO"/>unsubscribe?mail-invitation=YES


### PR DESCRIPTION
It was pointed out to me by my users that SOGo was sending out gender-specific emails regarding calendar ACL changes. This patch changes the instances I found to a more generic "their" instead of "him" or "his".
