### PR TITLE
Fix for free busy off by 23h after a dst change to summer time

### DIFF
--- a/UI/WebServerResources/JavascriptAPIExtensions.js
+++ b/UI/WebServerResources/JavascriptAPIExtensions.js
@@ -121,9 +121,19 @@ Date.prototype.clone = function() {
     return newDate;
 }
 
+Date.prototype.treatAsUTC = function() {
+    var result = new Date(this);
+    result.setMinutes(result.getMinutes() - result.getTimezoneOffset());
+    return result;
+}
+
 Date.prototype.deltaDays = function(otherDate) {
-    var day1 = this.getTime();
-    var day2 = otherDate.getTime();
+    // Thanks to http://stackoverflow.com/a/11252167/4703328
+    var day1UTC = this.treatAsUTC();
+    var day2UTC = otherDate.treatAsUTC();
+
+    var day1 = day1UTC.getTime();
+    var day2 = day2UTC.getTime();
     if (day1 > day2) {
         var tmp = day2;
         day2 = day1;
@@ -217,9 +227,9 @@ Date.prototype.stringWithSeparator = function(separator) {
 };
 
 Date.prototype.addDays = function(nbrDays) {
-    var milliSeconds = this.getTime();
-    milliSeconds += 86400000 * nbrDays;
-    this.setTime(milliSeconds);
+    // Thanks to http://stackoverflow.com/a/563442
+    var dat = new Date(this.valueOf());
+    this.setDate(dat.getDate() + nbrDays);
 };
 
 Date.prototype.earlierDate = function(otherDate) {


### PR DESCRIPTION
This was mentioned before on the mailing list (https://lists.inverse.ca/sogo/arc/users/2014-04/msg00023.html), but never solved (for what I could find).
Now I am facing the same bug, but it is reproducible.

The root is the 14 days range for which the client asks the free/busy data for being across a timezone change caused by daylight savings.

To reproduce:
- Set timezone to Europe/Brussels (or probably anything with daylight savings)
- Create an event on march, 31st 2015 for only current calendar or also add invitees
- Create an event on april, 1st 2015, open invite window
- There you see your event off march 31st, appearing on april 1st but off by 1h, both for your own calendar and the invitee calendar

This code change fixes the problem for this time. And probably all summer time changes, I have not tested the winter time changes, but I assume they did not have an error like this, although I guess the code of the free-busy should be checked, also on the server, as how it handles the dst changes and make it consistent.