### PR TITLE
Return appropiate error code when changing AD password with incorrect…

### DIFF
--- a/SoObjects/SOGo/LDAPSource.m
+++ b/SoObjects/SOGo/LDAPSource.m
@@ -737,7 +737,14 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
       }
   NS_HANDLER
     {
-      [self logWithFormat: @"%@", localException];
+      if ([[localException name] isEqual: @"LDAPException"] && ([[[localException userInfo] objectForKey: @"error_code"] intValue] == LDAP_CONSTRAINT_VIOLATION))
+        {
+          *perr = PolicyInsufficientPasswordQuality;
+        }
+      else
+        {
+          [self logWithFormat: @"%@", localException];
+        }
     }
   NS_ENDHANDLER ;
   


### PR DESCRIPTION
… complexity or length.

This show a 'complexity password error' in the UI instead of a generic code error.
There is not discrimination between complexity and length errors because backend does not
return different error codes for each case.

This requires https://github.com/Zentyal/sope/pull/12 in order to work

Suggested changes.md: 'Show correct error message when trying to change AD password with bad complexity or length'