### PR TITLE
various fixes for systemd service on RHEL7 

### DIFF
--- a/Scripts/sogo-systemd-redhat
+++ b/Scripts/sogo-systemd-redhat
@@ -3,8 +3,10 @@ Description=SOGo is a groupware server
 After=network.target
 
 [Service]
+Environment="PREFORK=3"
+EnvironmentFile=-/etc/sysconfig/sogo
 Type=forking
-ExecStart=/usr/sbin/sogod -WOWorkersCount 3 -WOPidFile /var/run/sogo/sogo.pid -WOLogFile /var/log/sogo/sogo.log
+ExecStart=/usr/sbin/sogod -WOWorkersCount ${PREFORK} -WOPidFile /var/run/sogo/sogo.pid -WOLogFile /var/log/sogo/sogo.log
 PIDFile=/var/run/sogo/sogo.pid
 User=sogo
 

--- a/packaging/rhel/sogo.spec
+++ b/packaging/rhel/sogo.spec
@@ -390,6 +390,7 @@ fi
 # update timestamp on imgs,css,js to let apache know the files changed
 find %{_libdir}/GNUstep/SOGo/WebServerResources  -exec touch {} \;
 %if 0%{?_with_systemd}
+  systemctl daemon-reload
   systemctl enable sogod
   systemctl start sogod > /dev/null 2>&1
 %else


### PR DESCRIPTION
Improvements around the systemd unit sogod.service on RHEL7 (and other systemd using distros) :
* Use the PREFORK parameter from /etc/sysconfig/sogo like the legacy init.d script does
* Reload systemd configuration after during postinst so that enable/start will actually work