### PR TITLE
Stage 3 of clang compiler warning patches.

### DIFF
--- a/SoObjects/Appointments/iCalRepeatableEntityObject+SOGo.m
+++ b/SoObjects/Appointments/iCalRepeatableEntityObject+SOGo.m
@@ -44,6 +44,7 @@
 #import <SOGo/NSCalendarDate+SOGo.h>
 
 #import "iCalRepeatableEntityObject+SOGo.h"
+#import "iCalCalendar+SOGo.h"
 
 @implementation iCalRepeatableEntityObject (SOGoExtensions)
 

--- a/SoObjects/Mailer/NSDictionary+Mail.m
+++ b/SoObjects/Mailer/NSDictionary+Mail.m
@@ -20,6 +20,7 @@
 
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSString.h>
+#import <NGExtensions/NSString+misc.h>
 
 #import "NSDictionary+Mail.h"
 

--- a/SoObjects/Mailer/SOGoMailBaseObject.m
+++ b/SoObjects/Mailer/SOGoMailBaseObject.m
@@ -32,9 +32,11 @@
 #import <NGExtensions/NSString+misc.h>
 #import <NGExtensions/NSURL+misc.h>
 #import <NGImap4/NGImap4Connection.h>
+#import <NGImap4/NGImap4Client.h>
 
 #import <SOGo/SOGoCache.h>
 #import <SOGo/SOGoUser.h>
+#import <SOGo/WORequest+SOGo.h>
 
 #import "SOGoMailAccount.h"
 #import "SOGoMailManager.h"

--- a/SoObjects/SOGo/SOGoCache.h
+++ b/SoObjects/SOGo/SOGoCache.h
@@ -21,6 +21,7 @@
 #ifndef SOGOCACHE_H
 #define SOGOCACHE_H
 
+#import <Foundation/Foundation.h>
 #import <Foundation/NSObject.h>
 
 #include <libmemcached/memcached.h>

--- a/UI/Common/WODirectAction+SOGo.m
+++ b/UI/Common/WODirectAction+SOGo.m
@@ -20,6 +20,7 @@
 
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSBundle.h>
+#import <Foundation/NSKeyValueCoding.h>
 
 #import <NGObjWeb/SoObjects.h>
 #import <NGObjWeb/WOContext+SoObjects.h>
@@ -30,6 +31,8 @@
 #import <SoObjects/SOGo/NSString+Utilities.h>
 #import <SoObjects/SOGo/SOGoUser.h>
 #import <SoObjects/SOGo/SOGoUserDefaults.h>
+
+#import <NGExtensions/NSObject+Logs.h>
 
 #import "WODirectAction+SOGo.h"
 

--- a/UI/Contacts/UIxContactFolderActions.m
+++ b/UI/Contacts/UIxContactFolderActions.m
@@ -28,10 +28,14 @@
 #import <NGObjWeb/NSException+HTTP.h>
 #import <NGObjWeb/WOContext.h>
 #import <NGObjWeb/WOResponse.h>
+#define COMPILING_NGOBJWEB 1 /* we want httpRequest for parsing multi-part
+                                form data */
 #import <NGObjWeb/WORequest.h>
+#undef COMPILING_NGOBJWEB
 #import <NGExtensions/NSString+misc.h>
 #import <NGExtensions/NSNull+misc.h>
 #import <NGExtensions/NGBase64Coding.h>
+#import <NGMime/NGMimeMultipartBody.h>
 
 #import <Contacts/SOGoContactObject.h>
 #import <Contacts/SOGoContactFolder.h>

--- a/UI/MailPartViewers/UIxMailPartICalActions.m
+++ b/UI/MailPartViewers/UIxMailPartICalActions.m
@@ -46,6 +46,7 @@
 #import <Mailer/SOGoMailObject.h>
 #import <SOGo/SOGoParentFolder.h>
 #import <SOGo/SOGoUser.h>
+#import <SOGo/NSString+Utilities.h>
 #import <Mailer/SOGoMailBodyPart.h>
 
 #import "UIxMailPartICalActions.h"

--- a/UI/MainUI/SOGoMicrosoftActiveSyncActions.m
+++ b/UI/MainUI/SOGoMicrosoftActiveSyncActions.m
@@ -30,6 +30,9 @@
 #import <NGObjWeb/WORequest.h>
 #import <NGObjWeb/WOResponse.h>
 
+#import <Common/WODirectAction+SOGo.h>
+#import <ActiveSync/SOGoActiveSyncDispatcher.h>
+
 @interface SOGoMicrosoftActiveSyncActions : WODirectAction
 @end
 

--- a/UI/PreferencesUI/UIxJSONPreferences.m
+++ b/UI/PreferencesUI/UIxJSONPreferences.m
@@ -32,6 +32,7 @@
 #import <SOGo/SOGoUserDefaults.h>
 #import <SOGo/SOGoUserSettings.h>
 #import <SOGo/SOGoUserProfile.h>
+#import <SOGo/WOResourceManager+SOGo.h>
 #import <Mailer/SOGoMailLabel.h>
 
 #import <SOGoUI/UIxComponent.h>


### PR DESCRIPTION
Stage 3:
Missing header file imports. These are need to clear objc-method-access warnings when using clang.