### PR TITLE
Stage 5 of clang compiler warning patches.

### DIFF
--- a/SoObjects/Appointments/SOGoAppointmentObject.m
+++ b/SoObjects/Appointments/SOGoAppointmentObject.m
@@ -46,6 +46,7 @@
 #import <NGCards/iCalDateTime.h>
 #import <NGCards/iCalTimeZone.h>
 #import <NGCards/iCalTimeZonePeriod.h>
+#import <NGCards/iCalToDo.h>
 #import <NGCards/NSString+NGCards.h>
 
 #import <SOGo/SOGoConstants.h>
@@ -748,11 +749,14 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
     {
       e = [events objectAtIndex: i];
       if ([e recurrenceId])
-        for (j = 0; j < [theAttendees count]; j++)
-          if (shouldAdd)
+        for (j = 0; j < [theAttendees count]; j++) {
+          if (shouldAdd) {
             [e addToAttendees: [theAttendees objectAtIndex: j]];
-          else
+          }
+          else {
             [e removeFromAttendees: [theAttendees objectAtIndex: j]];
+          }
+        }
     }
 }
 
@@ -1038,7 +1042,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
           if ([delegateEmail length])
             otherDelegate = [event findAttendeeWithEmail: delegateEmail];
           else
-            otherDelegate = NO;
+            otherDelegate = nil;
           
           /* we handle the addition/deletion of delegate users */
           addDelegate = NO;
@@ -1076,7 +1080,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
                   if ([delegateEmail length])
                     otherDelegate = [event findAttendeeWithEmail: delegateEmail];
                   else
-                    otherDelegate = NO;
+                    otherDelegate = nil;
                 }
             }
           if (addDelegate)
@@ -1233,7 +1237,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
               if ([delegateEmail length])
                 otherDelegate = [event findAttendeeWithEmail: delegateEmail];
               else
-                otherDelegate = NO;
+                otherDelegate = nil;
             }
           
           [self sendEMailUsingTemplateNamed: @"Deletion"

--- a/Tools/SOGoToolRestore.m
+++ b/Tools/SOGoToolRestore.m
@@ -574,6 +574,7 @@
           NSLog (@"  %@ (%@)",
                  folderKey, [currentFolder objectForKey: @"displayname"]);
         }
+      rc = YES;
     }
   else
     {


### PR DESCRIPTION
Stage 5:

Misc. fixes:
(i) Various fixes in SoObjects/Appointments/SOGoAppointmentObject.m. Missing header import, lack of curly brackets in for loops, use of BOOL (NO) instead of object (nil). 
(ii) Missing boolean return logic in method 'listRestorableFolders' in Tools/SOGoToolRestore.m.
