### PR TITLE
Stage 6 of clang compiler warning patches.

### DIFF
--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -142,8 +142,9 @@
 
 - (NSException *) changeParticipationStatus: (NSString *) newPartStat
                                withDelegate: (iCalPerson *) delegate
-                                      alarm: (iCalAlarm *) alarm;
+                                      alarm: (iCalAlarm *) alarm
 {
+  // Required for protocol <SOGoComponentOccurence>
   return nil;
 }
 

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -140,6 +140,13 @@
   return aclManager;
 }
 
+- (NSException *) changeParticipationStatus: (NSString *) newPartStat
+                               withDelegate: (iCalPerson *) delegate
+                                      alarm: (iCalAlarm *) alarm;
+{
+  return nil;
+}
+
 - (id) init
 {
   if ((self = [super init]))

--- a/SoObjects/SOGo/SOGoParentFolder.h
+++ b/SoObjects/SOGo/SOGoParentFolder.h
@@ -45,6 +45,7 @@
 
 - (NSException *) appendPersonalSources;
 - (void) removeSubFolder: (NSString *) subfolderName;
+- (NSException *) appendCollectedSources;
 
 - (void) setBaseOCSPath: (NSString *) newOCSPath;
 

--- a/SoObjects/SOGo/SOGoParentFolder.h
+++ b/SoObjects/SOGo/SOGoParentFolder.h
@@ -45,7 +45,6 @@
 
 - (NSException *) appendPersonalSources;
 - (void) removeSubFolder: (NSString *) subfolderName;
-- (NSException *) appendCollectedSources;
 
 - (void) setBaseOCSPath: (NSString *) newOCSPath;
 

--- a/SoObjects/SOGo/SOGoParentFolder.m
+++ b/SoObjects/SOGo/SOGoParentFolder.m
@@ -423,6 +423,38 @@ static SoSecurityManager *sm = nil;
   return error;
 }
 
+- (NSException *) appendCollectedSources
+{
+  GCSChannelManager *cm;
+  EOAdaptorChannel *fc;
+  NSURL *folderLocation;
+  NSString *sql, *gcsFolderType;
+  NSException *error;
+
+  cm = [GCSChannelManager defaultChannelManager];
+  folderLocation = [[GCSFolderManager defaultFolderManager] folderInfoLocation];
+  fc = [cm acquireOpenChannelForURL: folderLocation];
+  if ([fc isOpen])
+  {
+    gcsFolderType = [[self class] gcsFolderType];
+
+    sql = [NSString stringWithFormat: (@"SELECT c_path4 FROM %@"
+                                       @" WHERE c_path2 = '%@'"
+                                       @" AND c_folder_type = '%@'"),
+           [folderLocation gcsTableName], owner, gcsFolderType];
+  
+    error = [self fetchSpecialFolders: sql withChannel: fc andFolderType: SOGoCollectedFolder];
+
+    [cm releaseChannel: fc];
+  }
+  else
+    error = [NSException exceptionWithName: @"SOGoDBException"
+                                    reason: @"database connection could not be open"
+                                  userInfo: nil];
+ 
+  return error;
+}
+
 - (NSException *) initSubFolders
 {
   NSException *error;

--- a/SoObjects/SOGo/SOGoParentFolder.m
+++ b/SoObjects/SOGo/SOGoParentFolder.m
@@ -433,7 +433,7 @@ static SoSecurityManager *sm = nil;
       error = [self appendPersonalSources];
       if (!error)
         if ([self respondsToSelector:@selector(appendCollectedSources)])
-          error = [self respondsToSelector:@selector(appendCollectedSources)];
+          error = [self performSelector:@selector(appendCollectedSources)];
       if (!error)
         error = [self appendSystemSources]; // TODO : Not really a testcase, see function
       if (error)

--- a/SoObjects/SOGo/SOGoParentFolder.m
+++ b/SoObjects/SOGo/SOGoParentFolder.m
@@ -423,38 +423,6 @@ static SoSecurityManager *sm = nil;
   return error;
 }
 
-- (NSException *) appendCollectedSources
-{
-  GCSChannelManager *cm;
-  EOAdaptorChannel *fc;
-  NSURL *folderLocation;
-  NSString *sql, *gcsFolderType;
-  NSException *error;
-
-  cm = [GCSChannelManager defaultChannelManager];
-  folderLocation = [[GCSFolderManager defaultFolderManager] folderInfoLocation];
-  fc = [cm acquireOpenChannelForURL: folderLocation];
-  if ([fc isOpen])
-  {
-    gcsFolderType = [[self class] gcsFolderType];
-
-    sql = [NSString stringWithFormat: (@"SELECT c_path4 FROM %@"
-                                       @" WHERE c_path2 = '%@'"
-                                       @" AND c_folder_type = '%@'"),
-           [folderLocation gcsTableName], owner, gcsFolderType];
-  
-    error = [self fetchSpecialFolders: sql withChannel: fc andFolderType: SOGoCollectedFolder];
-
-    [cm releaseChannel: fc];
-  }
-  else
-    error = [NSException exceptionWithName: @"SOGoDBException"
-                                    reason: @"database connection could not be open"
-                                  userInfo: nil];
- 
-  return error;
-}
-
 - (NSException *) initSubFolders
 {
   NSException *error;
@@ -465,7 +433,7 @@ static SoSecurityManager *sm = nil;
       error = [self appendPersonalSources];
       if (!error)
         if ([self respondsToSelector:@selector(appendCollectedSources)])
-          error = [self appendCollectedSources];
+          error = [self respondsToSelector:@selector(appendCollectedSources)];
       if (!error)
         error = [self appendSystemSources]; // TODO : Not really a testcase, see function
       if (error)


### PR DESCRIPTION
Stage 6:

Missing method implementations:
(i) 'changeParticipationStatus' is a missing protocol method in SoObjects/Appointments/SOGoCalendarComponent.m. So I added a dummy one that just returns nil.
(ii) 'appendCollectedSources' is a missing method in 'SOGoParentFolder'. It does exist in a class called 'SOGoContactFolders' which is a subclass (child) of 'SOGoParentFolder'. So I copied that method to 'SOGoParentFolder'. If it's a redundant call as I suspect, it will not make a difference. But if it is called, my changes will fix a method call from failing at runtime. Ideally this should be looked into more thoroughly. However my fix will clears the compiler warning and will not make anything worse than it is already.
NOTE: 'appendCollectedSources' does not exist anywhere else, even in SOPE.
