### PR TITLE
Stage 7 of clang compiler warning patches.

### DIFF
--- a/SoObjects/Mailer/SOGoMailAccounts.m
+++ b/SoObjects/Mailer/SOGoMailAccounts.m
@@ -41,6 +41,8 @@
 
 #define XMLNS_INVERSEDAV @"urn:inverse:params:xml:ns:inverse-dav"
 
+// TODO: prune redundant methods
+
 @implementation SOGoMailAccounts
 
 - (NSArray *) mailAccounts
@@ -206,6 +208,9 @@
 </D:multistatus>
 
 */
+
+/* No longer in use, causes objc-method-access warning
+
 - (NSException *) setDavMailsLabels: (NSString *) newLabels
 {
   id <DOMElement> documentElement, labelNode;
@@ -253,5 +258,6 @@
 
   return nil;
 }
+*/
 
 @end /* SOGoMailAccounts */


### PR DESCRIPTION
Stage 7:

Fixes a objc-method-access warning. The method is no longer in use, so I commented it out and made a TODO note to remove redundant methods.