### PR TITLE
Stage 8 of clang compiler warning patches.

### DIFF
--- a/SoObjects/SOGo/WORequest+SOGo.m
+++ b/SoObjects/SOGo/WORequest+SOGo.m
@@ -172,34 +172,28 @@
 // Mac OS X/10.8.1 (12B19) AddressBook/1143
 // Mac OS X/10.8.2 (12C60) AddressBook/1167
 //
+
 - (BOOL) isMacOSXAddressBookApp
 {
   WEClientCapabilities *cc;
-  BOOL b;
+  BOOL isMacOSX_AB, hasAddressBook, hasCFNetwork, isMacOSX10_6_le, isMacOSX10_7, isMacOSX10_8_ge;
 
   cc = [self clientCapabilities];
 
-  b = (
-        (
-          (
-            [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
-            && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound
-          )
-          ||
-          (
-            [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
-            &&
-            (
-              [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound
-              ||
-              [[cc userAgent] rangeOfString: @"Mac_OS_X"].location != NSNotFound
-            )
-          )
-        )
-        && [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound
-      );
+  hasAddressBook = ( [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound \
+                       || [[cc userAgent] rangeOfString: @"Address%20Book"].location != NSNotFound );
+  hasCFNetwork = [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound;
 
-  return b;
+  // note that 'le' signifies less than or equal, 'ge' signifies greater than or equal
+  // these are only assumed from the user agent strings we currently know.
+
+  isMacOSX10_6_le = ( hasAddressBook && hasCFNetwork && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound );
+  isMacOSX10_7    = ( hasAddressBook && hasCFNetwork && [[cc userAgent] rangeOfString: @"Mac_OS_X"].location != NSNotFound );
+  isMacOSX10_8_ge = ( hasAddressBook && [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound );
+
+  isMacOSX_AB = ( isMacOSX10_6_le || isMacOSX10_7 || isMacOSX10_8_ge);
+
+  return isMacOSX_AB;
 }
 
 - (BOOL) isIPhoneAddressBookApp

--- a/SoObjects/SOGo/WORequest+SOGo.m
+++ b/SoObjects/SOGo/WORequest+SOGo.m
@@ -180,14 +180,24 @@
   cc = [self clientCapabilities];
 
   b = (
-       [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
-       && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound
-       || (
-           [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
-            || [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound
-           )
-       && [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound
-       );
+        (
+          (
+            [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
+            && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound
+          )
+          ||
+          (
+            [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
+            &&
+            (
+              [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound
+              ||
+              [[cc userAgent] rangeOfString: @"Mac_OS_X"].location != NSNotFound
+            )
+          )
+        )
+        && [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound
+      );
 
   return b;
 }

--- a/SoObjects/SOGo/WORequest+SOGo.m
+++ b/SoObjects/SOGo/WORequest+SOGo.m
@@ -172,7 +172,6 @@
 // Mac OS X/10.8.1 (12B19) AddressBook/1143
 // Mac OS X/10.8.2 (12C60) AddressBook/1167
 //
-
 - (BOOL) isMacOSXAddressBookApp
 {
   WEClientCapabilities *cc;

--- a/SoObjects/SOGo/WORequest+SOGo.m
+++ b/SoObjects/SOGo/WORequest+SOGo.m
@@ -175,24 +175,28 @@
 - (BOOL) isMacOSXAddressBookApp
 {
   WEClientCapabilities *cc;
-  BOOL isMacOSX_AB, hasAddressBook, hasCFNetwork, isMacOSX10_6_le, isMacOSX10_7, isMacOSX10_8_ge;
+  BOOL b;
 
   cc = [self clientCapabilities];
 
-  hasAddressBook = ( [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound \
-                       || [[cc userAgent] rangeOfString: @"Address%20Book"].location != NSNotFound );
-  hasCFNetwork = [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound;
+  b = (
+        (
+          [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
+          && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound
+        )
+        ||
+        (
+          [[cc userAgent] rangeOfString: @"CFNetwork"].location != NSNotFound
+          && [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound
+        )
+        ||
+        (
+          [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound
+          && [[cc userAgent] rangeOfString: @"AddressBook"].location != NSNotFound
+        )
+      );
 
-  // note that 'le' signifies less than or equal, 'ge' signifies greater than or equal
-  // these are only assumed from the user agent strings we currently know.
-
-  isMacOSX10_6_le = ( hasAddressBook && hasCFNetwork && [[cc userAgent] rangeOfString: @"Darwin"].location != NSNotFound );
-  isMacOSX10_7    = ( hasAddressBook && hasCFNetwork && [[cc userAgent] rangeOfString: @"Mac_OS_X"].location != NSNotFound );
-  isMacOSX10_8_ge = ( hasAddressBook && [[cc userAgent] rangeOfString: @"Mac OS X"].location != NSNotFound );
-
-  isMacOSX_AB = ( isMacOSX10_6_le || isMacOSX10_7 || isMacOSX10_8_ge);
-
-  return isMacOSX_AB;
+  return b;
 }
 
 - (BOOL) isIPhoneAddressBookApp


### PR DESCRIPTION
Stage 8: *CAUTION - needs testing*

Fixes ambiguous boolean logic caused by lack of brackets between AND and OR expressions. Since it's so ambiguous, I had to guess what was the correct logic. Without knowing the user-agent strings involved, this was my best estimation. Note that Ludovic reckons it looks OK in an email conversation. Ideally it needs testing.