### PR TITLE
Stage 9 of clang compiler warning patches.

### DIFF
--- a/SoObjects/SOGo/NSData+Crypto.m
+++ b/SoObjects/SOGo/NSData+Crypto.m
@@ -23,7 +23,7 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
 #include <crypt.h>
 #endif
 


### PR DESCRIPTION
Stage 9:

Fix build error on FreeBSD by including crypt.h from the base OS.