### PR TITLE
Fix path of Draft mailbox when reply and forward message

### DIFF
--- a/UI/MailerUI/UIxMailActions.m
+++ b/UI/MailerUI/UIxMailActions.m
@@ -61,7 +61,8 @@
   [newMail fetchMailForReplying: co toAll: toAll];
 
   accountName = [account nameInContainer];
-  mailboxName = [drafts relativeImap4Name];
+  mailboxName = [drafts absoluteImap4Name];
+  mailboxName = [mailboxName substringWithRange: NSMakeRange(1, [mailboxName length] -2)];
   messageName = [newMail nameInContainer];
 
   data = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -105,7 +106,8 @@
   [newMail fetchMailForForwarding: co];
 
   accountName = [account nameInContainer];
-  mailboxName = [drafts relativeImap4Name];
+  mailboxName = [drafts absoluteImap4Name];
+  mailboxName = [mailboxName substringWithRange: NSMakeRange(1, [mailboxName length] -2)];
   messageName = [newMail nameInContainer];
 
   data = [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
According to the commit 3f2c6efe7e50532620af9a8f8ef960cc8b68a2c4, that fixes the Bug #3439, I solved the same problem that happens when the user want to reply or forward an email. 
