### PR TITLE
fix (revised) for issue with CardDAV sync with the DAVDroid sync client.

### DIFF
--- a/SoObjects/Contacts/SOGoFolder+CardDAV.m
+++ b/SoObjects/Contacts/SOGoFolder+CardDAV.m
@@ -187,7 +187,10 @@
 
   // If no filters are provided, we return everything.
   if (![filters count])
-      [filters addObject: [NSDictionary dictionaryWithObject: @"."  forKey: @"mail"]];
+  {
+      [filters addObject: [NSDictionary dictionaryWithObject: @"." forKey: @"email"]];
+      [filters addObject: [NSDictionary dictionaryWithObject: @"%" forKey: @"name"]];
+  }
 
   return filters;
 }


### PR DESCRIPTION
This is a revised fix for the issue raiased in sogo bug tracker 3370 and 3373. It supercedes the fix in commit  2c723070c69899055b456119f6e8f42c279d0c57 .

The fix was noted in NEWS with the comment "we now return all cards when we receive an empty addressbook-query REPORT". However it did not work for me and at least two others, as can be seen in the commit comments. In summary, only contacts with email addresses were synced. The suggested change from kwirk fixes the regular address book sync, but it completely breaks syncing of the read-only Group Directory (Corporate Directory). My suggested changes work in full (as far as I'm able to test).

I have done some fairly extensive testing of CardDAV sync (with DAVDroid only) and it seems to work 100% now. In addition to the obvious tests, I have tested with contacts that only have one field of data entered. The feilds I've tested (with all other fields empty) are as follows:

First name
Last name
Display name
email address
Work (telephone)
Home (telephone)
Fax (telephone)
Mobile (telephone)

Additionally, I tested syncing of a contact with only the Work Address fully populated. In the webmail, since the name fields are all missing, the "Organization" field of the Work Address takes the place of the name field in the 'Name' column. This does get synced to my phone and it also appears my Android contact list with 'Name' set to the 'Organization' field data. The address, organization and website fields being in tact also.

In addition, I tested a Group Directory (Corporate Directory) [SOGoUserSources->isAddressBook] sync. It seems contacts without email addresses do not sync. This seems to be the behaviour across the board with a "." search filter. This happens despite the filter in SOGoUserSources including ldap entries without a mail attribute. Nothing I can do to patch this in SOGoFolder+CardDAV.m, that would have to be fixed in the code that deals with the special "." search filter (I guess).

I think the contact search system needs some looking into, particularly the "." search filter behaviour. There is another bug related to contact search in the webmail address book view. I will make a bug report on that soon. It's a shame there isn't an "all" search filter, it would seem it would make various parts of SOGo easier to get the right behaviour.