### PR TITLE
(Fix) Calendar view gets blank when Descending Order is selected

### DIFF
--- a/UI/Templates/SchedulerUI/UIxCalMainView.wox
+++ b/UI/Templates/SchedulerUI/UIxCalMainView.wox
@@ -514,7 +514,7 @@
                 </md-menu-item>
                 <md-menu-divider><!-- divider --></md-menu-divider>
                 <md-menu-item ng-if="list.componentType == 'events'">
-                  <md-button ng-href="#">
+                  <md-button>
                     <md-checkbox
                         ng-change="list.component.$filter(list.componentType)"
                         ng-model="list.component.$queryEvents.asc"
@@ -523,7 +523,7 @@
                   </md-button>
                 </md-menu-item>
                 <md-menu-item ng-if="list.componentType == 'tasks'">
-                  <md-button ng-href="#">
+                  <md-button>
                     <md-checkbox
                         ng-change="list.component.$filter(list.componentType)"
                         ng-model="list.component.$queryTasks.asc"


### PR DESCRIPTION
When you click on Descending Order while on Calendar View, the calendar was getting blank.