### PR TITLE
Prevents 'make prod' from failing on empty git-commits

### DIFF
--- a/UI/WebServerResources/GNUmakefile
+++ b/UI/WebServerResources/GNUmakefile
@@ -26,7 +26,11 @@ prod:
 	grunt --stack build
 	git update-index --no-assume-unchanged $(CSS_FILES) $(JS_FILES) $(JS_LIB_FILES)
 	git add -f $(CSS_FILES) $(JS_FILES) $(JS_LIB_FILES)
-	git commit -m "(js/css) Update generated files"
+	@if ! git diff --quiet --exit-code; then \
+		git commit -m "(js/css) Update generated files"; \
+	else \
+		echo "Nothing to commit; skipping git-commit"; \
+	fi
 	git update-index --assume-unchanged $(CSS_FILES) $(JS_FILES) $(JS_LIB_FILES)
 
 all:


### PR DESCRIPTION
This avoids useless error reports on automated builds.