### PR TITLE
Warning removal, next part.

### DIFF
--- a/SoObjects/Appointments/MSExchangeFreeBusy.m
+++ b/SoObjects/Appointments/MSExchangeFreeBusy.m
@@ -339,7 +339,7 @@ size_t curl_body_function_freebusy(void *ptr, size_t size, size_t nmemb, void *i
   NSMutableString *s;
 
   s = [NSMutableString stringWithCapacity: 64];
-  [s appendFormat:@"<0x%08X[%@]:", (unsigned int)self, NSStringFromClass([self class])];
+  [s appendFormat:@"<%p[%@]:", self, NSStringFromClass([self class])];
   if (freeBusyViewType)
     [s appendFormat:@" freeBusyViewType='%@'", freeBusyViewType];
   if (mergedFreeBusy)

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -130,6 +130,25 @@
   return aclManager;
 }
 
+- (void) setIsNew: (BOOL) newIsNew
+{
+  // Required for protocol <SOGoComponentOccurence>
+  // but not yet implemented.  Violently warn if
+  // used.
+  NSLog (@"SOGoCalendarComponent::setIsNew is not implemented.");
+  abort();
+}
+
+- (BOOL) isNew
+{
+  // Required for protocol <SOGoComponentOccurence>
+  // but not yet implemented.  Violently warn if
+  // used.
+  NSLog (@"SOGoCalendarComponent::isNew is not implemented.");
+  abort();
+  return false;
+}
+
 - (NSException *) changeParticipationStatus: (NSString *) newPartStat
                                withDelegate: (iCalPerson *) delegate
                                       alarm: (iCalAlarm *) alarm

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -132,21 +132,12 @@
 
 - (void) setIsNew: (BOOL) newIsNew
 {
-  // Required for protocol <SOGoComponentOccurence>
-  // but not yet implemented.  Violently warn if
-  // used.
-  NSLog (@"SOGoCalendarComponent::setIsNew is not implemented.");
-  abort();
+  [super setIsNew: newIsNew];
 }
 
 - (BOOL) isNew
 {
-  // Required for protocol <SOGoComponentOccurence>
-  // but not yet implemented.  Violently warn if
-  // used.
-  NSLog (@"SOGoCalendarComponent::isNew is not implemented.");
-  abort();
-  return false;
+  return [super isNew];
 }
 
 - (NSException *) changeParticipationStatus: (NSString *) newPartStat

--- a/SoObjects/Appointments/iCalEntityObject+SOGo.h
+++ b/SoObjects/Appointments/iCalEntityObject+SOGo.h
@@ -46,7 +46,7 @@ extern NSNumber *iCalDistantFutureNumber;
 
 - (iCalPerson *) participantForUser:  (SOGoUser *) theUser
                            attendee: (iCalPerson *) theAttendee;
-- (NSArray *) attendeeUIDs;
+/* - (NSArray *) attendeeUIDs; */
 - (BOOL) isStillRelevant;
 
 - (id) itipEntryWithMethod: (NSString *) method;

--- a/SoObjects/Mailer/SOGoDraftObject.h
+++ b/SoObjects/Mailer/SOGoDraftObject.h
@@ -114,7 +114,7 @@
 - (NSArray *) allBareRecipients;
 
 - (NSException *) delete;
-- (NSException *) sendMail;
+/* - (NSException *) sendMail; */
 - (NSException *) sendMailAndCopyToSent: (BOOL) copyToSent; /* default: YES */
 - (NSException *) save;
 

--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -69,6 +69,7 @@
 
 #import "SOGoDraftObject.h"
 
+
 static NSString *contentTypeValue = @"text/plain; charset=utf-8";
 static NSString *htmlContentTypeValue = @"text/html; charset=utf-8";
 static NSString *headerKeys[] = {@"subject", @"to", @"cc", @"bcc", 
@@ -1782,6 +1783,7 @@ static NSString    *userAgent      = nil;
 //
 //
 //
+/*
 - (NSException *) sendMail
 {
   SOGoUserDefaults *ud;
@@ -1843,6 +1845,7 @@ static NSString    *userAgent      = nil;
     }
   return [self sendMailAndCopyToSent: YES];
 }
+*/
 
 //
 //

--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -1116,7 +1116,7 @@ static NSString    *userAgent      = nil;
       pmime = [self pathToAttachmentWithName: [NSString stringWithFormat: @".%@.mime", name]];
       if (![[mimeType dataUsingEncoding: NSUTF8StringEncoding] writeToFile: pmime atomically: YES])
         {
-          [[NSFileManager defaultManager] removeItemAtPath: p error: nil];
+          [[NSFileManager defaultManager] removeItemAtPath: p error: NULL];
           return [NSException exceptionWithHTTPStatus: 500 /* Server Error */
                                                reason: @"Could not write attachment to draft!"];
         }

--- a/SoObjects/Mailer/SOGoMailAccounts.m
+++ b/SoObjects/Mailer/SOGoMailAccounts.m
@@ -234,7 +234,7 @@
           labelNode = [labelNodes objectAtIndex: count];
           
           label = [labelNode attribute: @"id"];
-          name = [labelNode textValue];
+          name = [[labelNode firstChild] nodeValue];
           color = [labelNode attribute: @"color"];
 
           [values addObject: name];

--- a/SoObjects/Mailer/SOGoMailFolder.h
+++ b/SoObjects/Mailer/SOGoMailFolder.h
@@ -99,8 +99,8 @@
 
 - (NSString *) davCollectionTag;
 
-- (NSArray *) syncTokenFieldsWithProperties: (NSDictionary *) properties
-                          matchingSyncToken: (NSString *) syncToken
+- (NSArray *) syncTokenFieldsWithProperties: (NSDictionary *) theProperties
+                          matchingSyncToken: (NSString *) theSyncToken
                                    fromDate: (NSCalendarDate *) theStartDate
                                 initialLoad: (BOOL) initialLoadInProgress;
 /* flags */

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -895,7 +895,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
         }
     }
 
-  return error;
+  return (WOResponse *) error;
 }
 
 - (NSDictionary *) statusForFlags: (NSArray *) flags

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -2245,18 +2245,13 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
   NSDictionary *d;
   id fetchResults;
 
-  int uidnext, highestmodseq, i; 
+  int highestmodseq, i;
 
   allTokens = [NSMutableArray array];
 
-  if ([theSyncToken isEqualToString: @"-1"])
-    {
-      uidnext = highestmodseq = 0;
-    }
-  else
+  if (![theSyncToken isEqualToString: @"-1"])
     {
       a = [theSyncToken componentsSeparatedByString: @"-"];
-      uidnext = [[a objectAtIndex: 0] intValue];
       highestmodseq = [[a objectAtIndex: 1] intValue];
     }
   

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -2234,7 +2234,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
 // 
 // FIXME: refactor MAPIStoreMailFolder.m - synchroniseCache to use this method
 //
-- (NSArray *) syncTokenFieldsWithProperties: (NSArray *) theProperties
+- (NSArray *) syncTokenFieldsWithProperties: (NSDictionary *) theProperties
                           matchingSyncToken: (NSString *) theSyncToken
                                    fromDate: (NSCalendarDate *) theStartDate
                                 initialLoad: (BOOL) initialLoadInProgress

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -2245,7 +2245,7 @@ _compareFetchResultsByMODSEQ (id entry1, id entry2, void *data)
   NSDictionary *d;
   id fetchResults;
 
-  int highestmodseq, i;
+  int highestmodseq = 0, i;
 
   allTokens = [NSMutableArray array];
 

--- a/SoObjects/SOGo/BSONCodec.m
+++ b/SoObjects/SOGo/BSONCodec.m
@@ -600,7 +600,7 @@ static NSDictionary *BSONTypes()
 
   /* We may have the zone using the UTC offset
      or abbreviation (deprecated) */
-  if (timezone && strlen(timezone) > 0 && (timezone[0] == '+' || timezone[0] == '-'))
+  if (strlen(timezone) > 0 && (timezone[0] == '+' || timezone[0] == '-'))
     {
       NSCalendarDate *tzDate;
 

--- a/SoObjects/SOGo/SOGoObject.m
+++ b/SoObjects/SOGo/SOGoObject.m
@@ -1046,8 +1046,8 @@
   if (nameInContainer) 
     [_ms appendFormat:@" name=%@", nameInContainer];
   if (container)
-    [_ms appendFormat:@" container=0x%08X/%@", 
-         (unsigned int)container, [container valueForKey:@"nameInContainer"]];
+    [_ms appendFormat:@" container=%p/%@", 
+         container, [container valueForKey:@"nameInContainer"]];
 }
 
 - (NSString *) description
@@ -1055,7 +1055,7 @@
   NSMutableString *ms;
 
   ms = [NSMutableString stringWithCapacity:64];
-  [ms appendFormat:@"<0x%08X[%@]:", (unsigned int) self, NSStringFromClass([self class])];
+  [ms appendFormat:@"<%p[%@]:", self, NSStringFromClass([self class])];
   [self appendAttributesToDescription:ms];
   [ms appendString:@">"];
 
@@ -1064,8 +1064,8 @@
 
 - (NSString *) loggingPrefix
 {
-  return [NSString stringWithFormat:@"<0x%08X[%@]:%@>",
-		   (unsigned int) self, NSStringFromClass([self class]),
+  return [NSString stringWithFormat:@"<%p[%@]:%@>",
+		   self, NSStringFromClass([self class]),
 		   [self nameInContainer]];
 }
 

--- a/Tests/Unit/TestSBJsonParser.m
+++ b/Tests/Unit/TestSBJsonParser.m
@@ -91,6 +91,7 @@
   test ([obtained compare: expected] == NSOrderedSame);
 #endif
 
+  locale = nil;
   result = [parser objectWithString: @"[ -312.3456 ]"];
   obtained = [result objectAtIndex: 0];
   expected = [NSDecimalNumber decimalNumberWithString: @"-312.3456" locale: locale];

--- a/UI/MailPartViewers/UIxMailPartICalViewer.h
+++ b/UI/MailPartViewers/UIxMailPartICalViewer.h
@@ -39,6 +39,11 @@
 }
 
 - (iCalEvent *) authorativeEvent;
+- (NSString *) endDate;
+- (NSString *) endTime;
+- (NSString *) startDate;
+- (NSString *) startTime;
+- (BOOL) isEndDateOnSameDay;
 
 @end
 

--- a/UI/MailerUI/UIxMailEditor.m
+++ b/UI/MailerUI/UIxMailEditor.m
@@ -869,7 +869,7 @@ static NSArray *infoKeys = nil;
     {
       error = [self validateForSend];
       if (!error)
-        error = [co sendMail];
+        error = [co sendMailAndCopyToSent: false];
       else
 	error = [self failedToSaveFormResponse: [error reason]];
     }

--- a/UI/MailerUI/UIxMailEditor.m
+++ b/UI/MailerUI/UIxMailEditor.m
@@ -869,7 +869,7 @@ static NSArray *infoKeys = nil;
     {
       error = [self validateForSend];
       if (!error)
-        error = [co sendMailAndCopyToSent: false];
+        error = [co sendMailAndCopyToSent: YES];
       else
 	error = [self failedToSaveFormResponse: [error reason]];
     }

--- a/UI/Scheduler/UIxCalFolderActions.m
+++ b/UI/Scheduler/UIxCalFolderActions.m
@@ -21,9 +21,15 @@
 */
 
 #import <Foundation/NSValue.h>
+
+#import <NGHttp/NGHttpRequest.h>
 #import <NGObjWeb/NSException+HTTP.h>
+#define COMPILING_NGOBJWEB 1 /* httpRequest is needed in
+                                importAction */
 #import <NGObjWeb/WORequest.h>
+#undef COMPILING_NGOBJWEB
 #import <NGObjWeb/WOResponse.h>
+#import <NGMime/NGMimeMultipartBody.h>
 
 #import <NGCards/iCalCalendar.h>
 


### PR DESCRIPTION
This series of fixes removes most of the remaining compilation warnings under GCC 4.9.

Some of the fixes are trivial, but others might have some unwanted side-effects.  Please review before merging.  Thanks.