### PR TITLE
Fixing bug when adding a tag to an email

### DIFF
--- a/UI/Templates/MailerUI/UIxMailViewTemplate.wox
+++ b/UI/Templates/MailerUI/UIxMailViewTemplate.wox
@@ -172,8 +172,8 @@
                       md-transform-chip="$chip.name"
                       md-on-remove="viewer.message.removeTag($chip)">
               <md-chip-template>
-                <span class="sg-chip-color" style="z-index: 1">
-                  <span ng-style="{ 'background-color': viewer.service.$tags[$chip][1] }"><!-- color --></span>
+                <span style="z-index: 1">
+                  <span ng-style="{ 'background-color': viewer.service.$tags[$chip][1] }">{{$chip}}<!-- color --></span>
                 </span>
                 <span>{{viewer.service.$tags[$chip][0]}}</span>
               </md-chip-template>


### PR DESCRIPTION
As reported in the Mailing List, there is a bug when creating a tag to an email.
The chip wasn't being showed. Also, this bug didn't let the user delete a tag.

The bug is fixed on this commit.