### PR TITLE
(doc) Add caveat on using a database host alias

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1350,6 +1350,26 @@ supported, such as MySQL and Oracle.
 First, make sure that your PostgreSQL server has TCP/IP connections
 support enabled.
 
+*Caveat: SOGo stores the database hostname together with table references
+inside several database tables.* To prevent possible future issues when moving
+the database to another host, it is best practice to add a local alias name to
+your `/etc/hosts` file, and using this in `/etc/sogo/sogo.conf` instead of the
+actual name of your server or localhost. When the database host name changes,
+you can now simply change the hosts file instead of updating several table
+columns replacing the old hostname. An example entry for `/etc/hosts` when
+running the database on the same host, registering `127.0.0.1` not only for
+`localhost`, but also the `db-alias` alias:
+
+ 127.0.0.1		localhost db-alias
+
+In the SOGo configuration, use the alias name instead of the real IP address or
+host name, for example
+
+----
+SOGoProfileURL =
+    "postgresql://sogo:sogo@db-alias:5432/sogo/sogo_user_profile";
+----
+
 Create the database user and schema using the following commands:
 
 ----


### PR DESCRIPTION
Recently, also because lots of people setup up additional SOGo 3 servers, issues with changed database names have repeatedly been reported on the mailing list.

I propose to add a caveat to the database documentation section, which requests the administrator to set up a database alias name to prevent such issues.

Setting up a [note paragraph](http://www.methods.co.nz/asciidoc/userguide.html#X28) might be more elegant than bold formatting, but right now I can't get the DocBook conversion running, so I sticked with "safe" formatting.