### PR TITLE
Add -O2 compilation by default and -g debug info

### DIFF
--- a/general.make
+++ b/general.make
@@ -1,3 +1,6 @@
+# Use GCC level 2 optimization by default
+# Might be overridden below
+ADDITIONAL_OBJCFLAGS=-O2
 ifeq ($(test-uninitialized),yes)
 ifeq ($(debug),yes)
 ADDITIONAL_OBJCFLAGS=-O0
@@ -5,3 +8,9 @@ else
 ADDITIONAL_OBJCFLAGS=-Wuninitialized
 endif
 endif
+# Ensure we store in the ELF files minimal debugging
+# information plus the compiler flags used; that can
+# be afterwards read with:
+# readelf -p .GCC.command.line /path/to/elf_file
+ADDITIONAL_OBJCFLAGS += -g -frecord-gcc-switches
+


### PR DESCRIPTION
Also store GCC command-line switches in the binaries for easier debugging.

Not 100% sure if this is the proper place in to add ad-hoc compiler flags in GNUstep-land, hence this pull request.

This is to address https://sogo.nu/bugs/view.php?id=2046