### PR TITLE
Supports multiple web domains in Apache.

### DIFF
--- a/Apache/SOGo.conf
+++ b/Apache/SOGo.conf
@@ -72,8 +72,8 @@ ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0
 ## and do not forget to enable the headers module
 <IfModule headers_module>
   RequestHeader set "x-webobjects-server-port" "443"
-#  RequestHeader set "x-webobjects-server-name" "yourhostname"
-#  RequestHeader set "x-webobjects-server-url" "https://yourhostname"
+  RequestHeader set "x-webobjects-server-name" "%{HTTP_HOST}e" env=HTTP_HOST
+  RequestHeader set "x-webobjects-server-url" "https://%{HTTP_HOST}e" env=HTTP_HOST
 
 ## When using proxy-side autentication, you need to uncomment and
 ## adjust the following line:


### PR DESCRIPTION
Using `%(HTTP_HOST)e` to support multiple web domains, and no change required by sys admin.