### PR TITLE
Do not force -frecord-gcc-switches flag

### DIFF
--- a/general.make
+++ b/general.make
@@ -1,3 +1,16 @@
+# Macros that allow testing for GCC flag existence
+try-run = $(shell set -e;                      \
+	TMP="/tmp/SOGo-gcc-flags-check.$$$$.tmp";  \
+	TMPO="/tmp/SOGo-gcc-flags-check.$$$$.o";   \
+	if ($(1)) >/dev/null 2>&1;                 \
+	then echo "$(2)";                          \
+	else echo "$(3)";                          \
+	fi;                                        \
+	rm -f "$$TMP" "$$TMPO")
+
+cc-option = $(call try-run,\
+	$(CC) $(1) -c -x c /dev/null -o "$$TMP",$(1),$(2))
+
 # Use GCC level 2 optimization by default
 # Might be overridden below
 ADDITIONAL_OBJCFLAGS=-O2
@@ -12,5 +25,5 @@ endif
 # information plus the compiler flags used; that can
 # be afterwards read with:
 # readelf -p .GCC.command.line /path/to/elf_file
-ADDITIONAL_OBJCFLAGS += -g -frecord-gcc-switches
+ADDITIONAL_OBJCFLAGS += -g $(call cc-option,-frecord-gcc-switches)
 


### PR DESCRIPTION
The `-frecord-gcc-switches` flag does not exist for
GCC < 4.3; hence only use it when available.

This is to address CentOS 5 compilation problems; related to previous commit 04d12f52f81c4929b37f26e4e24edbbaf636a5ea in pull request #210 