### PR TITLE
Fixing blank view when deleting a contact on AddressBook

### DIFF
--- a/UI/WebServerResources/js/Contacts/AddressBookController.js
+++ b/UI/WebServerResources/js/Contacts/AddressBookController.js
@@ -60,6 +60,7 @@
           var selectedCards = _.filter(vm.selectedFolder.$cards, function(card) { return card.selected; });
           vm.selectedFolder.$deleteCards(selectedCards);
           delete vm.selectedFolder.selectedCard;
+	   vm.mode.multiple = 0;
         });
     }
 

--- a/UI/WebServerResources/js/Contacts/Card.service.js
+++ b/UI/WebServerResources/js/Contacts/Card.service.js
@@ -261,7 +261,10 @@
         fn = this.c_org;
       }
       else if (this.emails && this.emails.length > 0) {
-        fn = _.find(this.emails, function(i) { return i.value !== ''; }).value;
+	 var name = _.find(this.emails, function(i) { return i.value !== ''; });
+	 if (name) {
+	    fn = name.value;
+	 }
       }
       else if (this.c_cn && this.c_cn.length > 0) {
         fn = this.c_cn;

--- a/UI/WebServerResources/js/Contacts/CardController.js
+++ b/UI/WebServerResources/js/Contacts/CardController.js
@@ -124,6 +124,7 @@
               AddressBook.selectedFolder.$cards = _.reject(AddressBook.selectedFolder.$cards, function(o) {
                 return o.id == card.id;
               });
+	      AddressBook.selectedFolder.$reload();
               close();
             }, function(data, status) {
               Dialog.alert(l('Warning'), l('An error occured while deleting the card "%{0}".',

--- a/UI/WebServerResources/js/Contacts/CardController.js
+++ b/UI/WebServerResources/js/Contacts/CardController.js
@@ -120,13 +120,13 @@
           // User confirmed the deletion
           card.$delete()
             .then(function() {
-              // Remove card from addressbook
-              AddressBook.selectedFolder.$cards = _.reject(AddressBook.selectedFolder.$cards, function(o) {
-                return o.id == card.id;
-              });
-	      AddressBook.selectedFolder.$reload();
-              close();
-            }, function(data, status) {
+	       // Remove card from addressbook
+	       AddressBook.selectedFolder.$cards = _.reject(AddressBook.selectedFolder.$cards, function(o) {
+		  return o.id == card.id;
+	       });
+	       AddressBook.selectedFolder.$reload();
+	       close();
+	    }, function(data, status) {
               Dialog.alert(l('Warning'), l('An error occured while deleting the card "%{0}".',
                                            card.$fullname()));
             });

--- a/UI/WebServerResources/js/Scheduler/CalendarListController.js
+++ b/UI/WebServerResources/js/Scheduler/CalendarListController.js
@@ -92,6 +92,7 @@
           Calendar.$deleteComponents(components).then(function() {
             $rootScope.$emit('calendars:list');
           });
+	   vm.mode.multiple = 0;
         });
     }
 


### PR DESCRIPTION
When testing SOGo, I was getting blank view in AddressBook list.

Steps to reproduce:
1 - Create 2 contacts.
2 - Click on the FIRST one.
3 - In the opened card, click on delete icon.
4 - Confirm the deleting operation.
5 - Gets blank view on AddressBook list of contacts.

This commit fixes this problem using a function already used in some others parts of the file.
As soon as the contact is deleted, it reloads the list, avoiding the blank view.