### PR TITLE
Fix the unrecognized selector exception in the fresh pieces of the EAS

### DIFF
--- a/ActiveSync/SOGoMailObject+ActiveSync.m
+++ b/ActiveSync/SOGoMailObject+ActiveSync.m
@@ -1003,7 +1003,7 @@ struct GlobalObjectId {
       [s appendFormat: @"<GlobalObjId xmlns=\"Email:\">%@</GlobalObjId>", [globalObjId activeSyncRepresentationInContext: context]];
 
       // We set the right message type - we must set AS version to 14.1 for this
-      if ([[context valueForKey: @"ASProtocolVersion"] floatValue] >= 14.1)
+      if ([[context objectForKey: @"ASProtocolVersion"] floatValue] >= 14.1)
         [s appendFormat: @"<MeetingMessageType xmlns=\"Email2:\">%d</MeetingMessageType>", 1];
 
       [s appendString: @"</MeetingRequest>"];
@@ -1169,7 +1169,7 @@ struct GlobalObjectId {
           truncated = 0;
         }
 
-      if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+      if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
         {
           [s appendFormat: @"<Body xmlns=\"Email:\">%@</Body>", content];
           [s appendFormat: @"<BodyTruncated xmlns=\"Email:\">%d</BodyTruncated>", truncated];
@@ -1204,7 +1204,7 @@ struct GlobalObjectId {
     {
       int i;
 
-      if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+      if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
         [s appendString: @"<Attachments xmlns=\"Email:\">"];
       else
         [s appendString: @"<Attachments xmlns=\"AirSyncBase:\">"];
@@ -1219,12 +1219,12 @@ struct GlobalObjectId {
           // FileReference must be a unique identifier across the whole store. We use the following structure:
           // mail/<foldername>/<message UID/<pathofpart>
           // mail/INBOX/2          
-          if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+          if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
             [s appendFormat: @"<AttName>mail/%@/%@/%@</AttName>", [[[self container] relativeImap4Name] stringByEscapingURL], [self nameInContainer], [value objectForKey: @"path"]];
           else
             [s appendFormat: @"<FileReference>mail/%@/%@/%@</FileReference>", [[[self container] relativeImap4Name] stringByEscapingURL], [self nameInContainer], [value objectForKey: @"path"]];
 
-          if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+          if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
             {
               [s appendFormat: @"<AttMethod>%d</AttMethod>", 1];
               [s appendFormat: @"<AttSize>%d</AttSize>", [[value objectForKey: @"size"] intValue]];
@@ -1273,7 +1273,7 @@ struct GlobalObjectId {
       [s appendFormat: @"</Categories>"];
     }
   
-    if ([[context valueForKey: @"ASProtocolVersion"] floatValue] >= 14.0)
+    if ([[context objectForKey: @"ASProtocolVersion"] floatValue] >= 14.0)
     {
       id value;
       NSString *reference;

--- a/ActiveSync/iCalEvent+ActiveSync.m
+++ b/ActiveSync/iCalEvent+ActiveSync.m
@@ -244,7 +244,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       // otherwise it'll prevent WP8 phones from sync'ing. See #3028 for details.
       o = [o activeSyncRepresentationInContext: context];
 
-      if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+      if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
         {
           [s appendFormat: @"<Body xmlns=\"Calendar:\">%@</Body>", o];
           [s appendString: @"<BodyTruncated xmlns=\"Calendar:\">0</BodyTruncated>"];
@@ -487,7 +487,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }
   
   // FIXME: merge with iCalToDo
-  if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+  if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
     {
       if ((o = [theValues objectForKey: @"Body"]))
         [self setComment: o];

--- a/ActiveSync/iCalToDo+ActiveSync.m
+++ b/ActiveSync/iCalToDo+ActiveSync.m
@@ -127,7 +127,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       // otherwise it'll prevent WP8 phones from sync'ing. See #3028 for details.
       o = [o activeSyncRepresentationInContext: context];
 
-      if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+      if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
         {
           [s appendFormat: @"<Body xmlns=\"Tasks:\">%@</Body>", o];
           [s appendString: @"<BodyTruncated xmlns=\"Tasks:\">0</BodyTruncated>"];
@@ -161,7 +161,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     [self setSummary: o];
 
   // FIXME: merge with iCalEvent
-  if ([[context valueForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
+  if ([[context objectForKey: @"ASProtocolVersion"] isEqualToString: @"2.5"])
     {
       if ((o = [theValues objectForKey: @"Body"]))
         [self setComment: o];


### PR DESCRIPTION
...implementation (by using `objectForKey` analoguously to the other the queries to context).

The fixed exception looked like this (caused by `valueForKey`):

    EXCEPTION: <NSException: 0x55f43f93e4d0> NAME:NSInvalidArgumentException REASON:-[WOContext ASProtocolVersion]: unrecognized selector sent to instance 0x55f43f307910 INFO:(null)
