### PR TITLE
Update SOGoInstallationGuide.asciidoc

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1666,8 +1666,10 @@ repository.
 authentication usernames (defaults to `c_uid` when unset).
 
 |MailFieldNames (optional)
-|Aan array of fields that specifies the column names that hold
+|An array of fields that specifies the column names that hold
 additional email addresses (beside the `mail` column) for each user.
+Values must be unique and not appear in more than one column.
+Space-separated values allowed in all *additional* columns (besides in `mail`).
 
 |IMAPHostFieldName (optional)
 |The field that returns the IMAP hostname for the user.


### PR DESCRIPTION
I tried adding a column `alias` to my view which contains a value that matches with the content of the column `mail`. AngularJS complains about a duplicate when it iterates through the array and fails.
It would be cool if Angular "cleans" the array and removes duplicates with some JS.