### PR TITLE
Change active state of "Remember username" switch

### DIFF
--- a/UI/Templates/MainUI/SOGoRootPage.wox
+++ b/UI/Templates/MainUI/SOGoRootPage.wox
@@ -83,7 +83,7 @@
 	    </var:if>
             
             <div layout="row" layout-align="center center">
-              <md-switch ng-model="app.creds.rememberLogin" label:arial-label="Remember username">
+              <md-switch class="md-accent md-hue-2" ng-model="app.creds.rememberLogin" label:arial-label="Remember username">
                 <var:string label:value="Remember username"/>
               </md-switch>
             </div>


### PR DESCRIPTION
If you activate "Remember username" on the login screen the switch would have the same color as the background. This makes the active state of the switch not really visible.

This changes the theming of this switch to use the same color as the login button.