### PR TITLE
Fixup empty calendars, sogod crashing when it tries to call

### DIFF
--- a/UI/Scheduler/UIxCalListingActions.m
+++ b/UI/Scheduler/UIxCalListingActions.m
@@ -492,7 +492,7 @@ static NSArray *tasksFields = nil;
               for (i = 0; i < count; i++)
                 {
                   currentInfo = [newInfoForComponent objectAtIndex: i];
-                  if ([currentInfo respondsToSelector: @selector (stringByEscapingHTMLString)])
+                  if (![currentInfo isEqual:[NSNull null]] && [currentInfo respondsToSelector: @selector (stringByEscapingHTMLString)])
                     [newInfoForComponent replaceObjectAtIndex: i withObject: [currentInfo stringByEscapingHTMLString]];
                 }
               [infos addObject: newInfoForComponent];


### PR DESCRIPTION
stringByEscapingHTMLString on NSNull objects. Those happen
to be there when not all fields of the calendar are filled
in. Leading to errors like:

ERROR(-[NSNull(misc) forwardInvocation:]): called selector stringByEscapingHTMLString on NSNull !
and subsequent crashes on the instance serving that request.

This happens for me on OpenBSD amd64, with gnustep:
gnustep-base-1.24.9p1 GNUstep base library
gnustep-libobjc2-1.8p0 GNUstep libobjc2 objective-c runtime
gnustep-make-2.6.8p0 GNUstep makefile package
everything compiled with clang.

on an a bit older system, this doesn't seem to happen, there I have gnustep:
gnustep-base-1.24.8p1 GNUstep base library
gnustep-libobjc2-1.8p0 GNUstep libobjc2 objective-c runtime
gnustep-make-2.6.7p1 GNUstep makefile package

sope/sogo installed are 2.3.17 in both cases

The backtrace looks like this:

```
Breakpoint 1, 0x00000012311fbef7 in -[NSException raise] (self=0x125c9e3650, _cmd=0x12319de358 <.objc_selector_list+144>) from /usr/local/lib/libgnustep-base.so.9.0
(gdb) bt
#0  0x00000012311fbef7 in -[NSException raise] (self=0x125c9e3650, _cmd=0x12319de358 <.objc_selector_list+144>) from /usr/local/lib/libgnustep-base.so.9.0
#1  0x00000012310eeb42 in -[GSMutableArray replaceObjectAtIndex:withObject:] (self=0x12542f7710, _cmd=0x1247d0d258 <.objc_selector_list+16>, index=10, anObject=0x0) at GSArray.m:880
#2  0x0000001247a46a19 in -[UIxCalListingActions _fetchFields:forComponentOfType:] (self=0x120bce2390, _cmd=0x1247d0d998 <.objc_selector_list+1872>, fields=0x12a6bb0110, component=0x1247d0c5b8 <.objc_str>)
    at UIxCalListingActions.m:496
#3  0x0000001247a48db7 in -[UIxCalListingActions eventsBlocksAction] (self=0x120bce2390, _cmd=0x122de50e20) at UIxCalListingActions.m:1104
#4  0x0000001231267963 in -[NSObject performSelector:] (self=0x120bce2390, _cmd=0x122fc3b360 <.objc_selector_list+288>, aSelector=0x122de50e20) at NSObject.m:2011
#5  0x000000122f337551 in -[WODirectAction performActionNamed:] (self=0x120bce2390, _cmd=0x122fd890a0 <.objc_selector_list+912>, _actionName=0x12c2ac9f10) at WODirectAction.m:97
#6  0x000000122f3e0e89 in -[SoActionInvocation callOnObject:withPositionalParametersWhenNotNil:inContext:] (self=0x12d10f2850, _cmd=0x122fd88e90 <.objc_selector_list+384>, _client=0x128631a310, _positionalArgs=0x0,
    _ctx=0x1297af5810) at SoActionInvocation.m:300
#7  0x000000122f3e0fa5 in -[SoActionInvocation callOnObject:inContext:] (self=0x12d10f2850, _cmd=0x122fd88da0 <.objc_selector_list+144>, _client=0x128631a310, _ctx=0x1297af5810) at SoActionInvocation.m:316           #8  0x000000122f3e0bee in
 -[SoActionInvocation callOnObject:withPositionalParametersWhenNotNil:inContext:] (self=0x1248eda010, _cmd=0x122fd88e90 <.objc_selector_list+384>, _client=0x128631a310, _positionalArgs=0x0,
    _ctx=0x1297af5810) at SoActionInvocation.m:259
#9  0x000000122f3e0fa5 in -[SoActionInvocation callOnObject:inContext:] (self=0x1248eda010, _cmd=0x122fd7c690 <.objc_selector_list+496>, _client=0x128631a310, _ctx=0x1297af5810) at SoActionInvocation.m:316
#10 0x000000122f3dac42 in -[SoObjectMethodDispatcher dispatchInContext:] (self=0x12fe606e70, _cmd=0x122fd7f8a0 <.objc_selector_list+880>, _ctx=0x1297af5810) at SoObjectMethodDispatcher.m:191
#11 0x000000122f3dd4c7 in -[SoObjectRequestHandler handleRequest:inContext:session:application:] (self=0x125ae6c090, _cmd=0x122fc5e4a8 <.objc_selector_list+336>, _rq=0x121337ec10, _ctx=0x1297af5810, _sn=0x0,
    app=0x122b39d110) at SoObjectRequestHandler.m:584
#12 0x000000122f34afef in -[WORequestHandler handleRequest:] (self=0x125ae6c090, _cmd=0x122fbeb930 <.objc_selector_list+1056>, _request=0x121337ec10) at WORequestHandler.m:237
#13 0x000000122f302a33 in -[WOCoreApplication dispatchRequest:usingHandler:] (self=0x122b39d110, _cmd=0x122fbebad0 <.objc_selector_list+1472>, _request=0x121337ec10, handler=0x125ae6c090) at WOCoreApplication.m:712
#14 0x000000122f302daa in -[WOCoreApplication dispatchRequest:] (self=0x122b39d110, _cmd=0x10055219f0 <.objc_selector_list+880>, _request=0x121337ec10) at WOCoreApplication.m:752                                      #15 0x00000010053025ee in
 -[SOGo dispatchRequest:] (self=0x122b39d110, _cmd=0x122fd5bd80 <.objc_selector_list+656>, _request=0x121337ec10) at SOGo.m:516
#16 0x000000122f3c970e in -[WOHttpTransaction _run] (self=0x12e6d27090, _cmd=0x122fd5bb10 <.objc_selector_list+32>) at WOHttpTransaction.m:596
#17 0x000000122f3c9b54 in -[WOHttpTransaction run] (self=0x12e6d27090, _cmd=0x122fd552b8 <.objc_selector_list+336>) at WOHttpTransaction.m:649
#18 0x000000122f3c497f in -[WOHttpAdaptor runConnection:] (self=0x121f025990, _cmd=0x122fd551c8 <.objc_selector_list+96>, _socket=0x12e6d27a10) at WOHttpAdaptor.m:373
#19 0x000000122f3c4bba in -[WOHttpAdaptor _handleAcceptedConnection:] (self=0x121f025990, _cmd=0x122fd55188 <.objc_selector_list+32>, _connection=0x12e6d27a10) at WOHttpAdaptor.m:407
#20 0x000000122f3c5076 in -[WOHttpAdaptor _handleConnection:] (self=0x121f025990, _cmd=0x122fd555b8 <.objc_selector_list+1104>, connection=0x12e6d27a10) at WOHttpAdaptor.m:466
#21 0x000000122f3c55a8 in -[WOHttpAdaptor acceptConnection:] (self=0x121f025990, _cmd=0x122fd55328 <.objc_selector_list+448>, _notification=0x12b747ad10) at WOHttpAdaptor.m:527
#22 0x0000001231267abb in -[NSObject performSelector:withObject:] (self=0x121f025990, _cmd=0x1231a3c190 <.objc_selector_list>, aSelector=0x122fd55328 <.objc_selector_list+448>, anObject=0x12b747ad10)
    at NSObject.m:2045                                                                                                                                                                                                  #23 0x000000123125220b in
 -[NSNotificationCenter _postAndRelease:] (self=0x123b450dd0, _cmd=0x1231a3c280 <.objc_selector_list+240>, notification=0x12b747ad10) at NSNotificationCenter.m:1306
#24 0x00000012312529d7 in -[NSNotificationCenter postNotificationName:object:userInfo:] (self=0x123b450dd0, _cmd=0x1231a3c360 <.objc_selector_list+464>, name=0x12b4fbe348 <.objc_str>, object=0x1244e88b90, info=0x0)
    at NSNotificationCenter.m:1366
#25 0x00000012312528a7 in -[NSNotificationCenter postNotificationName:object:] (self=0x123b450dd0, _cmd=0x12b4fbe5a8 <.objc_selector_list+48>, name=0x12b4fbe348 <.objc_str>, object=0x1244e88b90)
    at NSNotificationCenter.m:1346
#26 0x00000012b4c47952 in -[NSObject(FileObjectWatcher) receivedEvent:type:extra:forMode:] (self=0x1244e88b90, _cmd=0x1231ac14d0 <.objc_selector_list+112>, _fdData=0x8, _type=ET_RDESC, _extra=0x8,
    _mode=0x1231a59428 <.objc_str>) at NSRunLoop+FileObjects.m:57
#27 0x00000012313c799b in -[GSRunLoopCtxt pollUntil:within:] (self=0x1242d08210, _cmd=0x1231a5a518 <.objc_selector_list+496>, milliseconds=4568, contexts=0x1224f19850) at GSRunLoopCtxt.m:639
#28 0x00000012312b1e9e in -[NSRunLoop acceptInputForMode:beforeDate:] (self=0x1274d37990, _cmd=0x1231a5a358 <.objc_selector_list+48>, mode=0x1231a59428 <.objc_str>, limit_date=0x1242d09730) at NSRunLoop.m:1221       #29 0x00000012312b23ea in
 -[NSRunLoop runMode:beforeDate:] (self=0x1274d37990, _cmd=0x122fbeb6c0 <.objc_selector_list+432>, mode=0x1231a59428 <.objc_str>, date=0x1236088d90) at NSRunLoop.m:1292
#30 0x000000122f302211 in -[WOCoreApplication run] (self=0x122b39d110, _cmd=0x1005521790 <.objc_selector_list+272>) at WOCoreApplication.m:584
#31 0x0000001005301641 in -[SOGo run] (self=0x122b39d110, _cmd=0x122fc2e9a8 <.objc_selector_list+32>) at SOGo.m:277
#32 0x000000122f333136 in WOApplicationMain (_appClassName=0x100551f4a0 <.objc_str>, argc=7, argv=0x7f7ffffdbba8) at WOApplicationMain.m:42
#33 0x000000122f3580f1 in WOWatchDogApplicationMain (appName=0x100551f4a0 <.objc_str>, argc=7, argv=0x7f7ffffdbba8) at WOWatchDogApplicationMain.m:1049
#34 0x000000100530079e in gnustep_base_user_main (argc=7, argv=0x7f7ffffdbba8, env=0x7f7ffffdbbe8) at sogod.m:53
#35 0x00000012312963ea in main (argc=7, argv=0x7f7ffffdbba8, env=0x7f7ffffdbbe8) at NSProcessInfo.m:1002
#36 0x0000001005300572 in _start ()
```