### PR TITLE
Disable HTML entity encoding in CKEditor output

### DIFF
--- a/UI/WebServerResources/js/vendor/ckeditor/ck.js
+++ b/UI/WebServerResources/js/vendor/ckeditor/ck.js
@@ -53,6 +53,8 @@
         if (attr.ckOptions)
           options = angular.fromJson(attr.ckOptions.replace(/'/g, "\""));
 
+        options.entities = false;
+
         if (attr.ckLocale) {
           locale = $parse(attr.ckLocale)($scope);
           options.language = locale;


### PR DESCRIPTION
http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-entities

Avoid such ugly encoding in the html message part:
`τεστ` -> `&tau;&epsilon;&sigma;&tau;`
