### PR TITLE
Set the HTTP_HOST environment variable to enable preservation of the …

### DIFF
--- a/Apache/SOGo.conf
+++ b/Apache/SOGo.conf
@@ -72,6 +72,7 @@ ProxyPass /SOGo http://127.0.0.1:20000/SOGo retry=0
 ## and do not forget to enable the headers module
 <IfModule headers_module>
   RequestHeader set "x-webobjects-server-port" "443"
+  SetEnvIf Host (.*) HTTP_HOST=$1
   RequestHeader set "x-webobjects-server-name" "%{HTTP_HOST}e" env=HTTP_HOST
   RequestHeader set "x-webobjects-server-url" "https://%{HTTP_HOST}e" env=HTTP_HOST
 


### PR DESCRIPTION
…client's base URL.

Under normal circumstances, HTTP_HOST will not be set, and this results in a basic installation of SOGo redirecting clients to http: after login.