### PR TITLE
Create directories with 077X

### DIFF
--- a/packaging/debian/sogo.init
+++ b/packaging/debian/sogo.init
@@ -63,9 +63,9 @@ case "$1" in
 	log_daemon_msg "Starting $DESC" "$NAME"
 
         # Enforce directory existence and permissions
-        install -o $USER -g $USER -m 755 -d /var/run/$NAME
-        install -o $USER -g $USER -m 750 -d /var/spool/$NAME
-        install -o $USER -g $USER -m 750 -d /var/log/$NAME
+        install -o $USER -g $USER -m 775 -d /var/run/$NAME
+        install -o $USER -g $USER -m 770 -d /var/spool/$NAME
+        install -o $USER -g $USER -m 770 -d /var/log/$NAME
 
 	if ! start-stop-daemon -c $USER --quiet --start --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_OPTS 
 	then


### PR DESCRIPTION
Create directories with 077X. If we run 2 SOGo instances by following official tutorial[1], the second SOGo instance cannot start due to no permission to write pid file or log file.

[1] https://sogo.nu/nc/support/faq/article/dedicated-separate-sogo-instance-for-activesync.html