### PR TITLE
(fix) Added LDAPLookupFields attribute (fixes #568)

### DIFF
--- a/SoObjects/SOGo/LDAPSource.h
+++ b/SoObjects/SOGo/LDAPSource.h
@@ -75,6 +75,7 @@
   NSDictionary *modulesConstraints;
 
   NSMutableArray *searchAttributes;
+  NSArray *LDAPLookupFields;
   
   BOOL passwordPolicy;
   BOOL updateSambaNTLMPasswords;
@@ -110,6 +111,7 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
     IMAPLoginField: (NSString *) newIMAPLoginField
     SieveHostField: (NSString *) newSieveHostField
         bindFields: (id) newBindFields
+  LDAPLookupFields: (NSArray *) newLDAPLookupFields
 	 kindField: (NSString *) newKindField
 andMultipleBookingsField: (NSString *) newMultipleBookingsField;
 


### PR DESCRIPTION
As described in http://www.sogo.nu/bugs/view.php?id=568, SOGo lacks the possibility to retrieve operational LDAP attributes (like _memberOf_). This is caused by removing _searchAttributes_ in the belief that "*" does the same. This is correct, except for operational attributes.

To fix this, I added the optional LDAP source configuration _LDAPLookupFields_. It's default value is _("*")_ . Therefore it is fully backward compatible.

In my case, I can now have the following _sogo.conf_

```
  SOGoUserSources = (
    {
      type = ldap;

      LDAPLookupFields = ("*", "memberOf");

      ModulesConstraints = {
        Mail     = { memberOf = "cn=aclSogoMail,ou=Groups,dc=example,dc=com"; };
        Calendar = { memberOf = "cn=aclSogoCalendar,ou=Groups,dc=example,dc=com"; };
        Contacts = { memberOf = "cn=aclSogoContacts,ou=Groups,dc=example,dc=com"; };
      };
    }
  );
```

separate question: Can _searchAttributes_ be removed from the Interface?
_LDAPLookupFields_ should be described in the Installation Guide (but I didn't date to touch the *.odt file)
