### PR TITLE
Fix doc for SOGoVacationEnabled cron requirement

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -2031,9 +2031,9 @@ Requires Sieve script support on the IMAP host.
 
 Defaults to `NO` when unset.
 
-When enabling this parameter, one must also enable the associated
+When enabling this parameter, one can also enable the associated
 cronjob in `/etc/cron.d/sogo` in order to activate automatic vacation
-message expiration.
+message activation/expiration. But this feature should work without it using the sieve date extension.
 
 See the _Cronjob — Vacation messages expiration_ section below for
 details.


### PR DESCRIPTION
The cronjob to disable vacation message is not required anymore as of: v3.2.6 or https://github.com/inverse-inc/sogo/commit/3efe0e80983333e2f479872281d9d7ac45add8f0