### PR TITLE
Fix standard visibility macro use

### DIFF
--- a/SoObjects/SOGo/NSData+Crypto.m
+++ b/SoObjects/SOGo/NSData+Crypto.m
@@ -23,14 +23,9 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
-#include <crypt.h>
-#endif
+#define _XOPEN_SOURCE 600
 
 #include <fcntl.h>
-#include <unistd.h>
-
-#define _XOPEN_SOURCE 1
 #include <unistd.h>
 
 #if defined(HAVE_GNUTLS)


### PR DESCRIPTION
Expect crypt(3) to be provided by unistd.h, not the ancient crypt.h.
Update _XOPEN_SOURCE for SUSv3 / POSIX.1-2001