### PR TITLE
Fix to prevent lockout after password change using sha256-crypt/sha512-crypt

### DIFF
--- a/SoObjects/SOGo/LDAPSource.m
+++ b/SoObjects/SOGo/LDAPSource.m
@@ -626,6 +626,11 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
       return nil;
     }
 
+  if ([_userPasswordAlgorithm caseInsensitiveCompare: @"sha256-crypt"] == NSOrderedSame || [_userPasswordAlgorithm caseInsensitiveCompare: @"sha512-crypt"] == NSOrderedSame)
+    {
+      _userPasswordAlgorithm = @"CRYPT";
+    }
+
   return [NSString stringWithFormat: @"{%@}%@", _userPasswordAlgorithm, pass];
 }
 


### PR DESCRIPTION
If sha256-crypt or sha512-crypt is used LDAP users will lock themselves out when they change the password.

The bug was already fixed in the past:
https://sogo.nu/bugs/view.php?id=4137

I used the fix from Skrupellos and implemented it in the new version:
https://github.com/Skrupellos/sogo-patches/blob/v3.2.8/05-fix_crypt.patch
