### PR TITLE
Adjust word order in German reply template

### DIFF
--- a/SoObjects/Mailer/SOGoMailGermanReply.wo/SOGoMailGermanReply.html
+++ b/SoObjects/Mailer/SOGoMailGermanReply.wo/SOGoMailGermanReply.html
@@ -8,7 +8,7 @@ Datum: <#date/><#newLine/>
 Von: <#from/><#newLine/>
 <#hasReplyTo>Antwort an: <#replyTo/></#hasReplyTo><#hasOrganization>Organisation: <#organization/></#hasOrganization>An: <#to/><#newLine/>
 <#hasCc>Kopie: <#cc/></#hasCc><#hasNewsGroups>Newsgroup: <#newsgroups/></#hasNewsGroups><#hasReferences>Referenzen: <#references/></#hasReferences></#outlookMode><#newLine/>
-<#standardMode>Am <#date/>, <#from/> schrieb:</#standardMode><#newLine/>
+<#standardMode>Am <#date/>, schrieb <#from/>:</#standardMode><#newLine/>
 <#newLine/>
 <#messageBody/><#newLine/>
 <#replyPlacementOnBottom><#newLine/>


### PR DESCRIPTION
"schrieb" was in the wrong place, it has to go in front of the contact's name.