### PR TITLE
(fix) Fix SIGSEGV and compilation due to missing include crypt.h

### DIFF
--- a/SoObjects/SOGo/NSData+Crypto.m
+++ b/SoObjects/SOGo/NSData+Crypto.m
@@ -27,6 +27,9 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#include <crypt.h>
+#endif
 
 #if defined(HAVE_GNUTLS)
 #include <gnutls/gnutls.h>


### PR DESCRIPTION
When building on debian buster, the following warning occurs during
compiling:

    NSData+Crypto.m: In function ‘-[NSData(SOGoCryptoExtension) _asCryptedUsingSalt:magic:]’:
    NSData+Crypto.m:610:9: warning: implicit declaration of function ‘crypt’; did you mean ‘creat’? [-Wimplicit-function-declaration]
       buf = crypt([cryptString UTF8String], [saltString UTF8String]);
             ^~~~~
             creat
    NSData+Crypto.m:610:7: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
       buf = crypt([cryptString UTF8String], [saltString UTF8String]);
           ^
    NSData+Crypto.m: In function ‘-[NSData(SOGoCryptoExtension) asCryptUsingSalt:]’:
    NSData+Crypto.m:674:7: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
       buf = crypt([cryptString UTF8String], [saltString UTF8String]);
           ^
     Creating derived_src/NSFramework_SOGo.m..

This warning is apparently more severe as it may also cause segfaults
(at least on Debian Buster) when logging in, rendering sogo unusable:

    2019-07-21 11:27:55.623 sogod[16074:16074] MySQL4 connection established 0x0x55e6b9e56f40
    2019-07-21 11:27:55.624 sogod[16074:16074] MySQL4 channel 0x0x55e6b9aa41f0 opened (connection=0x0x55e6b9e56f40,sogo)
    2019-07-21 11:27:55.624 sogod[16074:16074] <MySQL4Channel[0x0x55e6b9aa41f0] connection=0x0x55e6b9e56f40> SQL: SELECT c_password FROM sogo_userview WHERE c_uid = 'xxxx';
    2019-07-21 11:27:55.625 sogod[16074:16074] <MySQL4Channel[0x0x55e6b9aa41f0] connection=0x0x55e6b9e56f40>   query has results, entering fetch-mode.
    Jul 21 11:27:56 sogod [16057]: <0x0x55e6b9a56020[WOWatchDogChild]> child 16074 exited
    Jul 21 11:27:56 sogod [16057]: <0x0x55e6b9a56020[WOWatchDogChild]>  (terminated due to signal 11)
    Jul 21 11:27:56 sogod [16057]: <0x0x55e6b992b360[WOWatchDog]> child spawned with pid 16268

The reason for this segfault is likely the implicit conversion to int,
leading to uninitialized higher bits of the pointer passed to NSData.