### PR TITLE
fixed .sg-date-group misplaced in CJK locales

### DIFF
--- a/UI/WebServerResources/scss/core/typography.scss
+++ b/UI/WebServerResources/scss/core/typography.scss
@@ -427,6 +427,7 @@ $today-font-size: 72px; // Visualy adjusted
   font-size: sg-size(button);
   line-height: 1;
   text-transform: uppercase;
+  word-break: keep-all;
 }
 
 .sg-date-today {


### PR DESCRIPTION
In CJK locales, .sg-day may be misplace.
In this case, word breaks should not be used for Chinese/Japanese/Korean (CJK) text. Non-CJK text behavior is the same as for normal.