### PR TITLE
Add support to set default SOGoMailShowSubscribedFoldersOnly.

### DIFF
--- a/UI/PreferencesUI/UIxJSONPreferences.m
+++ b/UI/PreferencesUI/UIxJSONPreferences.m
@@ -302,6 +302,9 @@ static SoProduct *preferencesProduct = nil;
   //
   // Default Mail preferences
   //
+  if (![[defaults source] objectForKey: @"SOGoMailShowSubscribedFoldersOnly"])
+    [[defaults source] setObject: [NSNumber numberWithBool: [defaults mailShowSubscribedFoldersOnly]] forKey: @"SOGoMailShowSubscribedFoldersOnly"];
+
   if (![[defaults source] objectForKey: @"SOGoMailComposeWindow"])
     [[defaults source] setObject: [defaults mailComposeWindow] forKey: @"SOGoMailComposeWindow"];
 


### PR DESCRIPTION
In the current situation, SOGo doesn't support for some configurable defaults. Especially hiding unsubscribed folders on first login looks like something desirable.