### PR TITLE
feat(core): support smtps

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1813,10 +1813,16 @@ are:
 |D |SOGoSMTPServer
 |The DNS name or IP address of the SMTP server used when
 _SOGoMailingMechanism_ is set to `smtp`.
+Supported formats are: `smtp://domain:port`, `smtps://domain`,
+`domain:port`, `smtp://domain:port/?tls=YES`. Using the option
+`tls=YES` will enforce using STARTTLS smtp connections. Thus,
+`smtp://localhost:587/?tls=YES` would use the default MUA port
+on localhost with STARTTLS enforced.
 
 |D |SOGoSMTPAuthenticationType
 |Activate SMTP authentication and specifies which type is in use.
-Current, only `PLAIN` is supported and other values will be ignored.
+Current, only `PLAIN` is supported and other values will cause
+the authentication to fail.
 
 |S |WOSendMail
 |The path of the sendmail binary.
@@ -2464,7 +2470,7 @@ like this:
     SOGoTrashFolderName = Trash;
     SOGoJunkFolderName = Junk;
     SOGoMailingMechanism = smtp;
-    SOGoSMTPServer = 127.0.0.1;
+    SOGoSMTPServer = "smtp://127.0.0.1";
     SOGoUserSources = (
         {
             type = ldap;

--- a/Scripts/sogo.conf
+++ b/Scripts/sogo.conf
@@ -26,7 +26,7 @@
   //SOGoTrashFolderName = Trash;
   //SOGoIMAPServer = "localhost";
   //SOGoSieveServer = "sieve://127.0.0.1:4190";
-  //SOGoSMTPServer = 127.0.0.1;
+  //SOGoSMTPServer = "smtp://127.0.0.1";
   //SOGoMailDomain = acme.com;
   //SOGoMailingMechanism = smtp;
   //SOGoForceExternalLoginWithEmail = NO;

--- a/SoObjects/SOGo/SOGoDefaults.plist
+++ b/SoObjects/SOGo/SOGoDefaults.plist
@@ -30,7 +30,7 @@
     SOGoLDAPContactInfoAttribute = "description";
 
     SOGoMailingMechanism = "sendmail";
-    SOGoSMTPServer = "localhost";
+    SOGoSMTPServer = "smtp://localhost";
     SOGoMailSpoolPath = "/var/spool/sogo";
 
     SOGoWebAccessEnabled = YES;

--- a/SoObjects/SOGo/SOGoDomainDefaults.m
+++ b/SoObjects/SOGo/SOGoDomainDefaults.m
@@ -281,7 +281,15 @@
 
 - (NSString *) smtpServer
 {
-  return [self stringForKey: @"SOGoSMTPServer"];
+  NSString *server;
+  server = [self stringForKey: @"SOGoSMTPServer"];
+  // backwards compatibility
+  if (![server hasPrefix: @"smtp://"] &&
+      ![server hasPrefix: @"smtps://"])
+    {
+      return [NSString stringWithFormat: @"smtp://%@", server];
+    }
+  return server;
 }
 
 - (NSString *) smtpAuthenticationType

--- a/SoObjects/SOGo/SOGoMailer.m
+++ b/SoObjects/SOGo/SOGoMailer.m
@@ -22,6 +22,7 @@
 
 #import <NGObjWeb/NSException+HTTP.h>
 #import <NGExtensions/NSObject+Logs.h>
+#import <NGExtensions/NSURL+misc.h>
 #import <NGMail/NGSendMail.h>
 #import <NGMail/NGSmtpClient.h>
 #import <NGMime/NGMimePartGenerator.h>
@@ -216,40 +217,27 @@
 }
 
 - (NSException *) _smtpSendData: (NSData *) mailData
-		   toRecipients: (NSArray *) recipients
-			 sender: (NSString *) sender
+                   toRecipients: (NSArray *) recipients
+                         sender: (NSString *) sender
               withAuthenticator: (id <SOGoAuthenticator>) authenticator
                       inContext: (WOContext *) woContext
 {
-  NSString *currentTo, *host, *login, *password;
-  NGInternetSocketAddress *addr;
+  NSString *currentTo, *login, *password;
   NSMutableArray *toErrors;
-  NSEnumerator *addresses; 
+  NSEnumerator *addresses;
   NGSmtpClient *client;
   NSException *result;
-  NSRange r;
-  unsigned int port;
+  NSURL * smtpUrl;
 
-  client = [NGSmtpClient smtpClient];
-  host = smtpServer;
   result = nil;
-  port = 25;
 
-  // We check if there is a port specified in the smtpServer ivar value
-  r = [smtpServer rangeOfString: @":"];
-  
-  if (r.length)
-    {
-      port = [[smtpServer substringFromIndex: r.location+1] intValue];
-      host = [smtpServer substringToIndex: r.location];
-    }
+  smtpUrl = [[[NSURL alloc] initWithString: smtpServer] autorelease];
 
-  addr = [NGInternetSocketAddress addressWithPort: port
-				  onHost: host];
+  client = [NGSmtpClient clientWithURL: smtpUrl];
 
   NS_DURING
     {
-      [client connectToAddress: addr];
+      [client connect];
       if ([authenticationType isEqualToString: @"plain"])
         {
           /* XXX Allow static credentials by peeking at the classname */
@@ -297,7 +285,7 @@
                                       @" (smtp) all recipients discarded"];
               else if ([toErrors count] > 0)
                 result = [NSException exceptionWithHTTPStatus: 500
-                                                       reason: [NSString stringWithFormat: 
+                                                       reason: [NSString stringWithFormat:
                                                                            @"cannot send message (smtp) - recipients discarded:\n%@",
                                                                          [toErrors componentsJoinedByString: @", "]]];
               else
@@ -313,7 +301,7 @@
     }
   NS_HANDLER
     {
-      [self errorWithFormat: @"Could not connect to the SMTP server %@ on port %d", host, port];
+      [self errorWithFormat: @"Could not connect to the SMTP server %@", smtpServer];
       result = [NSException exceptionWithHTTPStatus: 500
 					     reason: @"cannot send message:"
 			    @" (smtp) error when connecting"];


### PR DESCRIPTION
Support uri schemes for SMTP, enabling STARTTLS
and SMTPS for SMTP connections.
The new format for configuration value SMTPServer supports passing a
URI scheme (either smtp:// or smtps://). To support old configurations,
if no scheme is given, smtp:// is assumed.

Fixes [#31](https://sogo.nu/bugs/view.php?id=31)

Requires https://github.com/inverse-inc/sope/pull/50