### PR TITLE
feat(core): Support ARGON2I/ARGON2ID password hashes

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -229,9 +229,15 @@ Some of the softwares on which SOGo depends are available from the repository
 "Extra Packages for Enterprise Linux" (EPEL). To add EPEL to your packages
 sources, install the following package:
 
+On RHEL/CentOS 7,
 ----
 rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
+
+For RHEL/CentOS 8
+----
+yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+---
 
 SOGo relies on the GNUstep packages provided by Inverse and must not use the
 packages from EPEL. Adjust the repository definition to exclude those packages:
@@ -694,7 +700,7 @@ Defaults to `NO` when unset.
 For this feature to work properly when authenticating against AD or
 Samba4, the LDAP connection must use SSL/TLS. Server side restrictions
 can also cause the password change to fail, in which case SOGo will only
-log a 'Constraint violation (0x13)' error. These restrictions include 
+log a 'Constraint violation (0x13)' error. These restrictions include
 password too young, complexity constraints not satisfied, user cannot
 change password, etc...  Also note that Samba has a minimum password age
 of 1 day by default.
@@ -1299,9 +1305,9 @@ tweaking the `javax.net.ssl.trustStore` setting, either in the
 the SOGo certificate can also be added to the truststore as follows:
 
 ----
-openssl x509 -in /etc/ssl/certs/sogo-cert.pem -outform DER \ 
+openssl x509 -in /etc/ssl/certs/sogo-cert.pem -outform DER \
   -out /tmp/sogo-cert.der
-keytool -import -keystore /etc/ssl/certs/java/cacerts  \ 
+keytool -import -keystore /etc/ssl/certs/java/cacerts  \
   -file /tmp/sogo-cert.der -alias sogo-cert
 # The keystore password is 'changeit'
 # tomcat must be restarted after this operation
@@ -1315,7 +1321,7 @@ that file differs between distributions). Basically:
 
 ----
 # export tomcat's cert to openssl format
-keytool -keystore /etc/tomcat7/keystore  -exportcert -alias tomcat | \ 
+keytool -keystore /etc/tomcat7/keystore  -exportcert -alias tomcat | \
  openssl x509 -inform der >tomcat.pem
 
 Enter keystore password:  tomcat
@@ -1652,7 +1658,7 @@ present. Required columns are:
 * `c_name`: will be used to uniquely identify entries - which can be
   identical to `c_uid`
 * `c_password`: password of the user, plain text, crypt, md5 or sha
-  encoded 
+  encoded
 * `c_cn`: the user's common name
 * `mail`: the user's email address
 
@@ -1666,6 +1672,8 @@ passwords. Possible values are: `none`, `plain`, `crypt`, `md5`,
 `md5-crypt`, `smd5`, `cram-md5`, `ldap-md5`, and `sha`, `sha256`,
 `sha256-crypt`, `sha512`, `sha512-crypt`, its ssha (e.g. `ssha` or
 `ssha256`) variants, `blf-crypt`, `PBKDF2`, and `sym-aes-128-cbc`.
+The `argon2i` and `argon2id` password hashing algorithms are supported
+if SOGo is compiled with `libsodium`.
 Passwords can have the scheme prepended in the form
 `{scheme}encryptedPass`.
 
@@ -2707,7 +2715,7 @@ objectClass: inetOrgPerson
 objectClass: person
 objectClass: organizationalPerson
 uid: sogo
-cn: SOGo Administrator 
+cn: SOGo Administrator
 mail: sogo@acme.com
 sn: Administrator
 givenName: SOGo
@@ -2774,8 +2782,8 @@ Once installed, simply uncomment the following lines from your SOGo
 Apache configuration:
 
 ----
-ProxyPass /Microsoft-Server-ActiveSync \ 
-	http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \ 
+ProxyPass /Microsoft-Server-ActiveSync \
+	http://127.0.0.1:20000/SOGo/Microsoft-Server-ActiveSync \
 	retry=60 connectiontimeout=5 timeout=360
 ----
 
@@ -2861,7 +2869,7 @@ supported.
 Free/Busy feature of Outlook 2013/2016. Please
 see http://support.microsoft.com/kb/291621 for configuration
 instructions. On the SOGo side, _SOGoEnablePublicAccess_ must be set to
-`YES` and the URL to use must be of the following format: 
+`YES` and the URL to use must be of the following format:
 `http://<hostname>/SOGo/dav/public/%NAME%/freebusy.ifb`
 * If you have very large mail folders (thousands of messages), you will
 need to adjust the word size of your IMAP server. In Dovecot, the parameter
@@ -3154,7 +3162,7 @@ install -d -m 750 -o sogo -g sogo /etc/sogo
 sudo -u sogo sogo-tool dump-defaults > /etc/sogo/sogo.conf
 chown root:sogo /etc/sogo/sogo.conf
 chmod 640 /etc/sogo/sogo.conf
-sudo -u sogo mv ~/GNUstep/Defaults/.GNUstepDefaults \ 
+sudo -u sogo mv ~/GNUstep/Defaults/.GNUstepDefaults \
     ~/GNUstep/Defaults/GNUstepDefaults.old
 ----
 

--- a/SoObjects/SOGo/GNUmakefile.preamble
+++ b/SoObjects/SOGo/GNUmakefile.preamble
@@ -47,6 +47,11 @@ ifeq ($(HAS_LIBRARY_oath), yes)
 SOGo_LIBRARIES_DEPEND_UPON += $(MFA_LIBS)
 endif
 
+ifeq ($(HAS_LIBRARY_sodium), yes)
+ADDITIONAL_CPPFLAGS += -DHAVE_SODIUM=1 `pkg-config --cflags libsodium`
+SOGo_LIBRARIES_DEPEND_UPON += -lsodium
+endif
+
 ifeq ($(findstring openbsd, $(GNUSTEP_HOST_OS)), openbsd)
 SOGo_LIBRARIES_DEPEND_UPON += -lcrypto
 else

--- a/SoObjects/SOGo/NSData+Crypto.h
+++ b/SoObjects/SOGo/NSData+Crypto.h
@@ -58,6 +58,10 @@
 - (NSData *) asCryptUsingSalt: (NSData *) theSalt;
 - (NSData *) asMD5CryptUsingSalt: (NSData *) theSalt;
 - (NSData *) asBlowfishCryptUsingSalt: (NSData *) theSalt;
+#ifdef HAVE_SODIUM
+- (NSData *) asArgon2iUsingSalt: (NSData *) theSalt;
+- (NSData *) asArgon2idUsingSalt: (NSData *) theSalt;
+#endif /* HAVE_SODIUM */
 
 - (NSData *) extractSalt: (NSString *) theScheme;
 

--- a/Tests/Unit/GNUmakefile
+++ b/Tests/Unit/GNUmakefile
@@ -46,10 +46,14 @@ ADDITIONAL_LIB_DIRS += \
 	-Wl,-rpath,../../SoObjects/SOGo/SOGo.framework/Versions/Current/sogo -Wl,-rpath,../../SOPE/NGCards/obj -Wl,-rpath,../../SOPE/GDLContentStore/obj
 ADDITIONAL_LDFLAGS += -Wl,--no-as-needed
 
+ifeq ($(HAS_LIBRARY_sodium), yes)
+ADDITIONAL_CPPFLAGS += -DHAVE_SODIUM=1 `pkg-config --cflags libsodium`
+endif
+
+
 -include GNUmakefile.preamble
 include $(GNUSTEP_MAKEFILES)/test-tool.make
 -include GNUmakefile.postamble
 
 check :: $(TEST_TOOL)
 	./obj/sogo-tests
-

--- a/Tests/Unit/TestNSString+Crypto.m
+++ b/Tests/Unit/TestNSString+Crypto.m
@@ -112,4 +112,33 @@
   test([pbkdf2_key isEqualToCrypted:pkbf2_result withDefaultScheme: @"PBKDF2" keyPath: nil]);
 }
 
+#ifdef HAVE_SODIUM
+- (void) test_argon2
+{
+  NSString *error;
+  // well-known comparison
+  NSString *cleartext = @"123456";
+  NSString *hash = @"{ARGON2I}$argon2i$v=19$m=32768,t=4,p=1$HWg68rEbwmY6yrdByJ7U1g$z1c06BysT+51u1RXGtYIknTpA9jAHUfw1dAqPgTiQJ8";
+  NSString *prefix;
+  NSString *crypted_hash;
+
+  error = [NSString stringWithFormat:
+                          @"string '%@' wrong ARGON2ID: '%@'",
+                        cleartext, hash];
+  testWithMessage([cleartext isEqualToCrypted:hash withDefaultScheme: @"CRYPT" keyPath: nil], error);
+
+  // generate a new argon2id key
+  prefix = @"$argon2id$";
+  crypted_hash = [cleartext asCryptedPassUsingScheme: @"ARGON2ID" keyPath: nil];
+  fprintf(stdout, "hash = %s\n", [crypted_hash UTF8String]);
+
+  error = [NSString stringWithFormat:
+                          @"returned hash '%@' has incorrect ARGON2ID prefix: '%@'",
+                        crypted_hash, prefix];
+
+  testWithMessage([crypted_hash hasPrefix: prefix], error);
+  test([cleartext isEqualToCrypted:crypted_hash withDefaultScheme: @"ARGON2ID" keyPath: nil]);
+}
+#endif /* HAVE_SODUM */
+
 @end

--- a/configure
+++ b/configure
@@ -26,6 +26,7 @@ ARG_WITH_DEBUG=1
 ARG_WITH_STRIP=0
 ARG_ENABLE_SAML2=0
 ARG_ENABLE_MFA=0
+ARG_ENABLE_SODIUM=1
 ARG_WITH_LDAP_CONFIG=0
 
 GNUSTEP_INSTALLATION_DOMAIN="LOCAL"
@@ -78,7 +79,7 @@ Installation directories:
   --with-ssl=SSL          specify ssl library (none, ssl, gnutls, auto) [auto]
   --enable-saml2          enable support for SAML2 authentication (requires liblasso)
   --enable-mfa            enable multi-factor authentication (requires liboath)
-
+  --disable-sodium        disable building with libsodium (will disable argon2 password schemes)
   --enable-ldap-config    enable LDAP based configuration of SOGo
 
 _ACEOF
@@ -113,7 +114,12 @@ printParas() {
   else
     echo "  mfa support:  no";
   fi
-  if test $ARG_WITH_LDAP_CONFIG = 1; then 
+  if test $ARG_ENABLE_SODIUM = 1; then
+    echo "  argon2 support:  yes";
+  else
+    echo "  argon2 support:  no";
+  fi
+  if test $ARG_WITH_LDAP_CONFIG = 1; then
     echo "  ldap-based configuration:  yes";
   else
     echo "  ldap-based configuration:  no";
@@ -407,6 +413,9 @@ checkDependencies() {
           cfgwrite "MFA_LIBS := -loath"
       fi;
   fi
+  if test "x$ARG_ENABLE_SODIUM" = "x1"; then
+    checkLinking "sodium"   required;
+  fi
   if test "x$ARG_CFGSSL" = "xauto"; then
       checkLinking "ssl"     optional;
       if test $? != 0; then
@@ -500,6 +509,12 @@ processOption() {
 	;;
     "x--enable-mfa")
         ARG_ENABLE_MFA=1
+	;;
+    "x--enable-sodium")
+        ARG_ENABLE_SODIUM=1
+	;;
+    "x--disable-sodium")
+        ARG_ENABLE_SODIUM=0
 	;;
     "x--enable-ldap-config")
         ARG_WITH_LDAP_CONFIG=1

--- a/packaging/debian-multiarch/control
+++ b/packaging/debian-multiarch/control
@@ -1,7 +1,7 @@
 Source: sogo
 Priority: optional
 Maintainer: Inverse Support <support@inverse.ca>
-Build-Depends: debhelper (>= 8.0.0), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5), libzip-dev
+Build-Depends: debhelper (>= 8.0.0), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5), libzip-dev, libsodium-dev (>= 1.0.9) | base-files (<< 9.4ubuntu4~)
 Section: web
 Standards-Version: 3.9.2
 

--- a/packaging/debian-multiarch/rules
+++ b/packaging/debian-multiarch/rules
@@ -7,22 +7,53 @@ DESTDIR=$(CURDIR)/debian/tmp
 DIST_CODENAME=$(shell lsb_release -cs)
 SAML2_CONFIG=--enable-saml2
 
+# Debian 6
+ifeq ($(DIST_CODENAME), squeeze)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Debian 7
+ifeq ($(DIST_CODENAME), wheezy)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Debian 8
+ifeq ($(DIST_CODENAME), jessie)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Debian 9
 ifeq ($(DIST_CODENAME), stretch)
 MFA_CONFIG=--enable-mfa
 endif
 
+# Debian 10
 ifeq ($(DIST_CODENAME), buster)
 MFA_CONFIG=--enable-mfa
 endif
 
-ifeq ($(DIST_CODENAME), xenial)
-MFA_CONFIG=--enable-mfa
+# Ubuntu 12.04
+ifeq ($(DIST_CODENAME), precise)
+SODIUM_CONFIG=--disable-sodium
 endif
 
+# Ubuntu 14.04
+ifeq ($(DIST_CODENAME), trusty)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Ubuntu 16.04
+ifeq ($(DIST_CODENAME), xenial)
+MFA_CONFIG=--enable-mfa
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Ubuntu 18.04
 ifeq ($(DIST_CODENAME), bionic)
 MFA_CONFIG=--enable-mfa
 endif
 
+# Ubuntu 20.04
 ifeq ($(DIST_CODENAME), focal)
 MFA_CONFIG=--enable-mfa
 endif
@@ -32,19 +63,19 @@ include /usr/share/GNUstep/Makefiles/common.make
 
 config.make: configure
 	dh_testdir
-	./configure $(SAML2_CONFIG) $(MFA_CONFIG)
+	./configure $(SAML2_CONFIG) $(MFA_CONFIG) $(SODIUM_CONFIG)
 
 #Architecture
 build: build-arch
 
 build-arch: build-arch-stamp
-build-arch-stamp:  config.make 
+build-arch-stamp:  config.make
 #	 Add here commands to compile the arch part of the package.
 	$(MAKE)
 	(cd ActiveSync && $(MAKE))
 	touch $@
 
-clean: 
+clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-arch-stamp
@@ -57,7 +88,7 @@ clean:
 	fi
 	-rm -f config.make
 	(cd ActiveSync; $(MAKE) clean); \
-	dh_clean 
+	dh_clean
 
 install: install-arch
 	dh_testdir

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,7 +1,7 @@
 Source: sogo
 Priority: optional
 Maintainer: Inverse Support <support@inverse.ca>
-Build-Depends: debhelper (>= 7.0.15), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5), libzip-dev
+Build-Depends: debhelper (>= 7.0.15), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5), libzip-dev, libsodium-dev (>= 1.0.9) | base-files (<< 9.4ubuntu4~)
 Section: web
 Standards-Version: 3.9.1
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -6,26 +6,54 @@ export DH_VERBOSE=1
 DESTDIR=$(CURDIR)/debian/tmp
 DIST_CODENAME=$(shell lsb_release -cs)
 
+# Debian 6
 ifeq ($(DIST_CODENAME), squeeze)
 SAML2_CONFIG=--enable-saml2
+SODIUM_CONFIG=--disable-sodium
 endif
 
+# Debian 7
+ifeq ($(DIST_CODENAME), wheezy)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Debian 8
+ifeq ($(DIST_CODENAME), jessie)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Debian 9
 ifeq ($(DIST_CODENAME), stretch)
 MFA_CONFIG=--enable-mfa
 endif
 
+# Debian 10
 ifeq ($(DIST_CODENAME), buster)
 MFA_CONFIG=--enable-mfa
 endif
 
-ifeq ($(DIST_CODENAME), xenial)
-MFA_CONFIG=--enable-mfa
+# Ubuntu 12.04
+ifeq ($(DIST_CODENAME), precise)
+SODIUM_CONFIG=--disable-sodium
 endif
 
+# Ubuntu 14.04
+ifeq ($(DIST_CODENAME), trusty)
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Ubuntu 16.04
+ifeq ($(DIST_CODENAME), xenial)
+MFA_CONFIG=--enable-mfa
+SODIUM_CONFIG=--disable-sodium
+endif
+
+# Ubuntu 18.04
 ifeq ($(DIST_CODENAME), bionic)
 MFA_CONFIG=--enable-mfa
 endif
 
+# Ubuntu 20.04
 ifeq ($(DIST_CODENAME), focal)
 MFA_CONFIG=--enable-mfa
 endif
@@ -35,19 +63,19 @@ include /usr/share/GNUstep/Makefiles/common.make
 
 config.make: configure
 	dh_testdir
-	./configure $(SAML2_CONFIG) $(MFA_CONFIG)
+	./configure $(SAML2_CONFIG) $(MFA_CONFIG) $(SODIUM_CONFIG)
 
 #Architecture
 build: build-arch
 
 build-arch: build-arch-stamp
-build-arch-stamp:  config.make 
+build-arch-stamp:  config.make
 #	 Add here commands to compile the arch part of the package.
 	$(MAKE)
 	(cd ActiveSync && $(MAKE))
 	touch $@
 
-clean: 
+clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-arch-stamp
@@ -60,7 +88,7 @@ clean:
 	fi
 	-rm -f config.make
 	(cd ActiveSync; $(MAKE) clean); \
-	dh_clean 
+	dh_clean
 
 install: install-arch
 	dh_testdir

--- a/packaging/rhel/sogo.spec
+++ b/packaging/rhel/sogo.spec
@@ -49,6 +49,14 @@ BuildRequires:  gcc-objc gnustep-base gnustep-make sope%{sope_major_version}%{so
 %{?el8:Requires: liboath}
 %{?el8:BuildRequires: liboath-devel}
 
+%if 0%{?rhel} >= 7
+Requires: libsodium
+BuildRequires: libsodium-devel
+%define sodium_cfg_opts "--enable-sodium"
+%else
+%define sodium_cfg_opts "--disable-sodium"
+%endif
+
 %description
 SOGo is a groupware server built around OpenGroupware.org (OGo) and
 the SOPE application server.  It focuses on scalability.
@@ -164,15 +172,15 @@ rm -fr ${RPM_BUILD_ROOT}
 %else
 . /usr/share/GNUstep/Makefiles/GNUstep.sh
 %endif
-./configure %saml2_cfg_opts %mfa_cfg_opts
+./configure %saml2_cfg_opts %mfa_cfg_opts %sodium_cfg_opts
 
 case %{_target_platform} in
-ppc64-*) 
+ppc64-*)
   cc="gcc -m64";
-  ldflags="-m64";; 
+  ldflags="-m64";;
 *)
   cc="gcc";
-  ldflags="";; 
+  ldflags="";;
 esac
 
 make CC="$cc" LDFLAGS="$ldflags" messages=yes


### PR DESCRIPTION
Requires libsodium ≥ 1.0.9 to be present at compile time.

Thus, the following distributions will have support for at least
ARGON2i:

* rhel ≥ 7
* Debian ≥ 9 (stretch)
* Ubuntu ≥ Bionic (18.04)

Fixes [#4895](https://sogo.nu/bugs/view.php?id=4895)


Regarding packaging. I checked the required version of libsodium and determined the minimal distribution version. Default for libsodium is enabled. If the distribution is too old, simply disable libsodium/argon2. In this way there is no need to adjust the packaging if there is a new distribution