### PR TITLE
feat(core): Add PBKDF2 support 

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1660,8 +1660,9 @@ they have the same name as popular LDAP attributes (such as `givenName`,
 passwords. Possible values are: `none`, `plain`, `crypt`, `md5`,
 `md5-crypt`, `smd5`, `cram-md5`, `ldap-md5`, and `sha`, `sha256`,
 `sha256-crypt`, `sha512`, `sha512-crypt`, its ssha (e.g. `ssha` or
-`ssha256`) variants, `blf-crypt`, and `sym-aes-128-cbc`. Passwords
-can have the scheme prepended in the form `{scheme}encryptedPass`.
+`ssha256`) variants, `blf-crypt`, `PBKDF2`, and `sym-aes-128-cbc`.
+Passwords can have the scheme prepended in the form
+`{scheme}encryptedPass`.
 
 If no scheme is given, _userPasswordAlgorithm_ is used instead. The
 schemes listed above follow the algorithms described in

--- a/SoObjects/SOGo/GNUmakefile
+++ b/SoObjects/SOGo/GNUmakefile
@@ -167,7 +167,7 @@ SOGo_OBJC_FILES = \
 	SOGoCredentialsFile.m		\
 	SOGoTextTemplateFile.m
 
-SOGo_C_FILES += lmhash.c aes.c crypt_blowfish.c
+SOGo_C_FILES += lmhash.c aes.c crypt_blowfish.c pkcs5_pbkdf2.c
 
 SOGo_RESOURCE_FILES = \
 	SOGoDefaults.plist \

--- a/SoObjects/SOGo/NSData+Crypto.h
+++ b/SoObjects/SOGo/NSData+Crypto.h
@@ -54,7 +54,7 @@
 - (NSData *) asSymAES128CBCUsingIV: (NSString *) theIV
                            keyPath: (NSString *) theKeyPath;
 - (NSData *) asCramMD5;
-
+- (NSData *) asPBKDF2SHA1UsingSalt: (NSData *) theSalt;
 - (NSData *) asCryptUsingSalt: (NSData *) theSalt;
 - (NSData *) asMD5CryptUsingSalt: (NSData *) theSalt;
 - (NSData *) asBlowfishCryptUsingSalt: (NSData *) theSalt;

--- a/SoObjects/SOGo/NSString+Utilities.m
+++ b/SoObjects/SOGo/NSString+Utilities.m
@@ -739,7 +739,7 @@ static int cssEscapingCount;
   substrLen = [substring length];
 
   matchRange = NSMakeRange (0, selfLen);
-  while (!done)
+  while (!done && matchRange.length > 0)
     {
       substrRange = [self rangeOfString: substring options: 0 range: matchRange];
       if (substrRange.location == NSNotFound)

--- a/SoObjects/SOGo/pkcs5_pbkdf2.h
+++ b/SoObjects/SOGo/pkcs5_pbkdf2.h
@@ -1,0 +1,15 @@
+#ifndef PKCS5_PBKDF2_H
+#define PKCS5_PBKDF2_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define PBKDF2_KEY_SIZE_SHA1 (20)
+#define PBKDF2_SALT_LEN (16)
+#define PBKDF2_DEFAULT_ROUNDS (5000)
+
+int
+pkcs5_pbkdf2(const char *pass, size_t pass_len, const uint8_t *salt,
+    size_t salt_len, uint8_t *key, size_t key_len, unsigned int rounds);
+
+#endif /* ! PKCS5_PBKDF2_H */

--- a/Tests/Unit/TestNSString+Crypto.m
+++ b/Tests/Unit/TestNSString+Crypto.m
@@ -1,6 +1,7 @@
-/* TestNSString+MD5SHA1.m - this file is part of SOGo
+/* TestNSString+Crypto.m - this file is part of SOGo
  *
  * Copyright (C) 2011, 2012 Jeroen Dekkers
+ * Copyright (C) 2020 Nicolas Höft
  *
  * Author: Jeroen Dekkers <jeroen@dekkers.ch>
  *
@@ -83,6 +84,32 @@
   testWithMessage([blf_result hasPrefix: blf_prefix], error);
 
   test([blf_key isEqualToCrypted:blf_result withDefaultScheme: @"BLF-CRYPT" keyPath: nil]);
+}
+
+- (void) test_pbkdf2
+{
+  NSString *error;
+  // well-known comparison
+  NSString *pbkdf2_key = @"123456";
+  NSString *pbkdf2_hash = @"{PBKDF2}$1$xbhnwhLxltdS9L5M$5001$f1699047a6132383490817d6e58a5284f13339f0";
+  NSString *pkbf2_prefix;
+  NSString *pkbf2_result;
+
+  error = [NSString stringWithFormat:
+                          @"string '%@' wrong PBKDF2: '%@'",
+                        pbkdf2_key, pbkdf2_hash];
+  testWithMessage([pbkdf2_key isEqualToCrypted:pbkdf2_hash withDefaultScheme: @"CRYPT" keyPath: nil], error);
+
+  // generate a new pbkdf2-crypt key
+  pkbf2_prefix = @"$1$";
+  pkbf2_result = [pbkdf2_key asCryptedPassUsingScheme: @"PBKDF2" keyPath: nil];
+
+  error = [NSString stringWithFormat:
+                          @"returned hash '%@' has incorrect PBKDF2 prefix: '%@'",
+                        pkbf2_result, pkbf2_prefix];
+
+  testWithMessage([pkbf2_result hasPrefix: pkbf2_prefix], error);
+  test([pbkdf2_key isEqualToCrypted:pkbf2_result withDefaultScheme: @"PBKDF2" keyPath: nil]);
 }
 
 @end


### PR DESCRIPTION
Extend NSData+Crypto to support PBKDF2 with SHA1 HMAC as dovecot
is using it since v2.3.0.

The format hashed passwords is `{PBKDF2}$1$<salt>$<rounds>$<hashed value in hex>`

The implementation of pkcs#5 PBKDF2 is taken from openbsd (with minor
adjustments) as OpenSSL and GnuTLS would require quite new versions to
support this hash.