### PR TITLE
Allow settings override in sogo-backup.sh

### DIFF
--- a/Scripts/sogo-backup.sh
+++ b/Scripts/sogo-backup.sh
@@ -4,9 +4,9 @@ set -o pipefail
 #set -x
 PROGNAME="$(basename $0)"
 
-BACKUP_DIR=~sogo/backups
+BACKUP_DIR=${BACKUP_DIR:-~sogo/backups}
 SOGO_TOOL=/usr/sbin/sogo-tool
-DAYS_TO_KEEP="30"
+DAYS_TO_KEEP=${DAYS_TO_KEEP:-30}
 
 DATE=$(date +%F_%H%M)
 LOG="logger -t $PROGNAME -p daemon.info"


### PR DESCRIPTION
This PR allows a sysadmin to override BACKUP_DIR and DAYS_TO_KEEP by setting an environment variable.
It makes it possible to set the variables directly in crontab files.