### PR TITLE
feat(core): add lookupFields attribute in LDAP source

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1028,6 +1028,11 @@ _bindDN_ and _bindPassword_ will still be required to find the proper DN
 |bindFields (optional)
 |An array of fields to use when doing indirect binds.
 
+|lookupFields (optional)
+|Lookup fields for LDAP queries. Default is `(*)`. This can be utilized
+to lookup operational fields (which are per default not part of the result)
+such as `memberOf`: `lookupFields = ("*", "memberOf");`
+
 |hostname
 |A space-delimited list of LDAP URLs or LDAP hostnames.
 
@@ -1106,7 +1111,7 @@ not work for entries in this source and thus, freebusy lookups.
 repository
 
 |listRequiresDot (optional)
-|If set to `YES`, listing of this LDAP source is only possible when performing a search (respecting the SOGoSearchMinimumWordLength parameter) or when explicitely typing a single dot.
+|If set to `YES`, listing of this LDAP source is only possible when performing a search (respecting the SOGoSearchMinimumWordLength parameter) or when explicitly typing a single dot.
 Defaults to `YES` when unset.
 
 |ModulesConstraints (optional)

--- a/SoObjects/SOGo/LDAPSource.h
+++ b/SoObjects/SOGo/LDAPSource.h
@@ -75,6 +75,7 @@
   NSMutableDictionary *_members;
 
   NSDictionary *_modulesConstraints;
+  NSArray *_lookupFields;
 
   BOOL _passwordPolicy;
   BOOL _updateSambaNTLMPasswords;
@@ -110,6 +111,7 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
     IMAPLoginField: (NSString *) newIMAPLoginField
     SieveHostField: (NSString *) newSieveHostField
         bindFields: (id) newBindFields
+      lookupFields: (NSArray *) newLookupFields
 	 kindField: (NSString *) newKindField
 andMultipleBookingsField: (NSString *) newMultipleBookingsField;
 


### PR DESCRIPTION
This field allows for looking up attributes not returned with the
default query, such as operational attributes.

Fixes [#568](https://sogo.nu/bugs/view.php?id=568)

Rebased version of PR https://github.com/inverse-inc/sogo/pull/235 with additional documentation