### PR TITLE
Use libzip API instead of zip command line tool for creating zip archives

### DIFF
--- a/SoObjects/SOGo/GNUmakefile
+++ b/SoObjects/SOGo/GNUmakefile
@@ -87,7 +87,8 @@ SOGo_HEADER_FILES = \
 	WOContext+SOGo.h		\
 	\
 	SOGoCredentialsFile.h		\
-	SOGoTextTemplateFile.h
+	SOGoTextTemplateFile.h		\
+	SOGoZipArchiver.h
 
 all::
 	@touch SOGoBuild.m
@@ -167,7 +168,8 @@ SOGo_OBJC_FILES = \
 	WOContext+SOGo.m		\
 	\
 	SOGoCredentialsFile.m		\
-	SOGoTextTemplateFile.m
+	SOGoTextTemplateFile.m		\
+	SOGoZipArchiver.m
 
 SOGo_C_FILES += lmhash.c
 

--- a/SoObjects/SOGo/SOGoZipArchiver.h
+++ b/SoObjects/SOGo/SOGoZipArchiver.h
@@ -1,0 +1,38 @@
+/* SOGoCredentialsFile.h - this file is part of SOGo
+ *
+ * Copyright (C) 2013 Inverse inc.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#ifndef SOGOZIPARCHIVER_H
+#define SOGOZIPARCHIVER_H
+
+#include <zip.h>
+
+@interface SOGoZipArchiver : NSObject
+{
+  zip_t *zip;
+}
+
+- (id) initFromFile: (NSString *) file;
++ (id) archiverAtPath: (NSString *) file;
+
+- (BOOL) putFileWithName: (NSString *) filename andData: (NSData *) data;
+- (BOOL) close;
+@end
+
+#endif /* SOGOZIPARCHIVER_H */

--- a/SoObjects/SOGo/SOGoZipArchiver.h
+++ b/SoObjects/SOGo/SOGoZipArchiver.h
@@ -1,6 +1,6 @@
-/* SOGoCredentialsFile.h - this file is part of SOGo
+/* SOGoZipArchiver.h - this file is part of SOGo
  *
- * Copyright (C) 2013 Inverse inc.
+ * Copyright (C) 2020 Inverse inc.
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/SoObjects/SOGo/SOGoZipArchiver.m
+++ b/SoObjects/SOGo/SOGoZipArchiver.m
@@ -1,6 +1,6 @@
-/* SOGoCredentialsFile.m - this file is part of SOGo
+/* SOGoZipArchiver.m - this file is part of SOGo
  *
- * Copyright (C) 2013 Inverse inc.
+ * Copyright (C) 2020 Inverse inc.
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/SoObjects/SOGo/SOGoZipArchiver.m
+++ b/SoObjects/SOGo/SOGoZipArchiver.m
@@ -1,0 +1,107 @@
+/* SOGoCredentialsFile.m - this file is part of SOGo
+ *
+ * Copyright (C) 2013 Inverse inc.
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#import <Foundation/NSCharacterSet.h>
+#import <Foundation/NSData.h>
+
+#import "SOGoZipArchiver.h"
+
+@implementation SOGoZipArchiver
+
++ (id)archiverAtPath:(NSString *)file
+{
+    id newArchiver = [[self alloc] initFromFile: file];
+    [newArchiver autorelease];
+    return newArchiver;
+}
+
+- (id)init
+{
+    if ((self = [super init])) {
+        zip = NULL;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self close];
+    [super dealloc];
+}
+
+- (id)initFromFile:(NSString *)file
+{
+    id ret;
+
+    ret = nil;
+    if (file) {
+        if ((self = [self init])) {
+            int errorp;
+            self->zip = zip_open([file cString], ZIP_CREATE | ZIP_EXCL, &errorp);
+            if (self->zip == NULL) {
+                zip_error_t ziperror;
+                zip_error_init_with_code(&ziperror, errorp);
+                NSLog(@"Failed to open zip output file %@: %@", file,
+                        [NSString stringWithCString: zip_error_strerror(&ziperror)]);
+            } else {
+                ret = self;
+            }
+        }
+    }
+
+    return ret;
+}
+
+- (BOOL)putFileWithName:(NSString *)filename andData:(NSData *)data
+{
+    if (self->zip == NULL) {
+        NSLog(@"Failed to add file, archive is not open");
+        return NO;
+    }
+
+    zip_source_t *source = zip_source_buffer(self->zip, [data bytes], [data length], 0);
+    if (source == NULL) {
+        NSLog(@"Failed to create zip source from buffer: %@", [NSString stringWithCString: zip_strerror(self->zip)]);
+        return NO;
+    }
+
+    if (zip_file_add(self->zip, [filename UTF8String], source, ZIP_FL_ENC_UTF_8) < 0) {
+        NSLog(@"Failed to add file %@: %@", filename, [NSString stringWithCString: zip_strerror(self->zip)]);
+        zip_source_free(source);
+    }
+
+    return YES;
+}
+
+- (BOOL)close
+{
+    BOOL success = YES;
+    if (self->zip != NULL) {
+        if (zip_close(zip) != 0) {
+            NSLog(@"Failed to close zip archive: %@", [NSString stringWithCString: zip_strerror(self->zip)]);
+            zip_discard(self->zip);
+            success = NO;
+        }
+        self->zip = NULL;
+    }
+    return success;
+}
+
+@end

--- a/configure
+++ b/configure
@@ -379,7 +379,7 @@ EOF
 }
 
 checkDependencies() {
-  cfgwrite "BASE_LIBS := `gnustep-config --base-libs`"
+  cfgwrite "BASE_LIBS := `gnustep-config --base-libs` -lzip"
   if test "x$ARG_ENABLE_SAML2" = "x1"; then
       checkLinking "lasso"   required;
       if test $? = 0; then

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,14 +1,14 @@
 Source: sogo
 Priority: optional
 Maintainer: Inverse Support <support@inverse.ca>
-Build-Depends: debhelper (>= 7.0.15), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5)
+Build-Depends: debhelper (>= 7.0.15), gobjc | objc-compiler, libgnustep-base-dev, libsope-appserver4.9-dev, libsope-core4.9-dev, libsope-gdl1-4.9-dev, libsope-ldap4.9-dev, libsope-mime4.9-dev, libsope-xml4.9-dev, libmemcached-dev, libxml2-dev, libsbjson-dev, libssl-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libwbxml2-dev (>= 0.11.2), liblasso3-dev (>= 2.3.5), libzip-dev
 Section: web
 Standards-Version: 3.9.1
 
 Package: sogo
 Section: web
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, sope4.9-libxmlsaxdriver, sope4.9-db-connector, gnustep-make, libcurl3 | libcurl4, zip, liblasso3 (>= 2.3.5)
+Depends: ${shlibs:Depends}, ${misc:Depends}, sope4.9-libxmlsaxdriver, sope4.9-db-connector, gnustep-make, libcurl3 | libcurl4, libzip4, liblasso3 (>= 2.3.5)
 Recommends: memcached, apache2 | nginx | httpd
 Description: a modern and scalable groupware
  SOGo is a groupware server built around OpenGroupware.org (OGo) and


### PR DESCRIPTION
This PR eliminitates the need of the zip command line tool for creating zip archives (used for mailfolder exports, attachment downloads) by using libzip directly. The files are directly compressed from their memory buffer and do not need to be saved on disk any more. 

A further even stronger optimzation is to use an extended version of WOMessage/WOHttpTransaction in SOPE (the respective PR will follow shortly) allowing to serve the zip file directly as HTTP response instead of loading the whole file into memory as until now. 