### PR TITLE
chore(rpm): do not try to start service

### DIFF
--- a/packaging/rhel/sogo.spec
+++ b/packaging/rhel/sogo.spec
@@ -363,7 +363,6 @@ find %{_docdir}/ -name '*.sh' -exec chmod a+x {} \;
 %if 0%{?_with_systemd}
   systemctl daemon-reload
   systemctl enable sogod
-  systemctl start sogod > /dev/null 2>&1
 %else
   /sbin/chkconfig --add sogod
   /etc/init.d/sogod condrestart  >&/dev/null


### PR DESCRIPTION
- If it's initial install, `sogo.conf` is not yet ready to start (no SQL username/password, etc).
- If it's package upgrade, `start` should be replaced by `restart`.
- If sogo can not start before package upgrade, upgrading will produce error like below. Issue reported here: https://sogo.nu/bugs/view.php?id=5073

```
warning: %post(sogo-4.3.2.20200708-1.el7.x86_64) scriptlet failed, exit status 1
Non-fatal POSTIN scriptlet failure in rpm package sogo-4.3.2.20200708-1.el7.x86_64
```