### PR TITLE
fix(mail): change default search scope to "subject or from"

### DIFF
--- a/UI/Templates/MailerUI/UIxMailFolderTemplate.wox
+++ b/UI/Templates/MailerUI/UIxMailFolderTemplate.wox
@@ -139,9 +139,9 @@
         </md-input-container>
         <md-input-container flex="25">
           <md-select label:aria-label="Search scope">
-            <md-option value="subject" selected="selected"><var:string label:value="Subject"/></md-option>
+            <md-option value="subject_or_from" selected="selected"><var:string label:value="Subject or Sender"/></md-option>
+            <md-option value="subject"><var:string label:value="Subject"/></md-option>
             <md-option value="from"><var:string label:value="Sender"/></md-option>
-            <md-option value="subject_or_from"><var:string label:value="Subject or Sender"/></md-option>
             <md-option value="to_or_cc"><var:string label:value="To or Cc"/></md-option>
             <md-option value="body"><var:string label:value="Entire Message"/></md-option>
           </md-select>


### PR DESCRIPTION
update default search behavior from `subject` to `subject_or_from`. This is more user friendly for most of users.