### PR TITLE
fix(preferences(js)): always apply forward constraints to sieve filters

### DIFF
--- a/UI/WebServerResources/js/Preferences/PreferencesController.js
+++ b/UI/WebServerResources/js/Preferences/PreferencesController.js
@@ -356,10 +356,7 @@
 
       domains = [];
 
-      if ($window.forwardConstraints > 0 &&
-          angular.isDefined(Preferences.defaults.Forward) &&
-          Preferences.defaults.Forward.enabled &&
-          angular.isDefined(Preferences.defaults.Forward.forwardAddress)) {
+      if ($window.forwardConstraints > 0) {
 
         // We first extract the list of 'known domains' to SOGo
         defaultAddresses = $window.defaultEmailAddresses;
@@ -396,7 +393,8 @@
       // We do some sanity checks
 
       // We check if we're allowed or not to forward based on the domain defaults
-      if (this.preferences.defaults.Forward && this.preferences.defaults.Forward.forwardAddress) {
+      if (this.preferences.defaults.Forward && this.preferences.defaults.Forward.enabled &&
+          this.preferences.defaults.Forward.forwardAddress) {
         addresses = this.preferences.defaults.Forward.forwardAddress;
         try {
           for (i = 0; i < addresses.length; i++) {


### PR DESCRIPTION
This is a fix for issue 8649. So far an active forward constraint has only be applied to the sieve filters if a forward address had been set and activated in the forward preferences tab.