### PR TITLE
refactor(mail): replace "Google Authenticator" with more general vocabulary

### DIFF
--- a/UI/MainUI/BrazilianPortuguese.lproj/Localizable.strings
+++ b/UI/MainUI/BrazilianPortuguese.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Código de verificação";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Digite o código de verificação de 6 dígitos do seu aplicativo Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Você forneceu uma chave inválida do Google Authenticator.";
+"Enter the 6-digit verification code from your TOTP application." = "Digite o código de verificação de 6 dígitos do seu aplicativo Google Authenticator.";
+"You provided an invalid TOTP key." = "Você forneceu uma chave inválida do Google Authenticator.";
 
 "Download" = "Download";
 "Language" = "Idioma";

--- a/UI/MainUI/Catalan.lproj/Localizable.strings
+++ b/UI/MainUI/Catalan.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Codi de verificació";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Introdueix el codi de verificació de 6 dígits de l'aplicació Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Has proporcionat una clau de Google Authenticator invàlida.";
+"Enter the 6-digit verification code from your TOTP application." = "Introdueix el codi de verificació de 6 dígits de l'aplicació Google Authenticator.";
+"You provided an invalid TOTP key." = "Has proporcionat una clau de Google Authenticator invàlida.";
 
 "Download" = "Descàrrega";
 "Language" = "Llengua";

--- a/UI/MainUI/Czech.lproj/Localizable.strings
+++ b/UI/MainUI/Czech.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Ověřovací kód";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Zadejte 6-ti místný číselný ověřovací kód z Vaší aplikace Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Zadali jste neplatný ověřovací kód z Google Authenticator.";
+"Enter the 6-digit verification code from your TOTP application." = "Zadejte 6-ti místný číselný ověřovací kód z Vaší aplikace Google Authenticator.";
+"You provided an invalid TOTP key." = "Zadali jste neplatný ověřovací kód z Google Authenticator.";
 
 "Download" = "Stáhnout";
 "Language" = "Jazyk";

--- a/UI/MainUI/English.lproj/Localizable.strings
+++ b/UI/MainUI/English.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Verification Code";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Enter the 6-digit verification code from your Google Authenticator application.";
-"You provided an invalid Google Authenticator key." = "You provided an invalid Google Authenticator key.";
+"Enter the 6-digit verification code from your TOTP application." = "Enter the 6-digit verification code from your TOTP application.";
+"You provided an invalid TOTP key." = "You provided an invalid TOTP key.";
 
 "Download" = "Download";
 "Language" = "Language";

--- a/UI/MainUI/French.lproj/Localizable.strings
+++ b/UI/MainUI/French.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Code de vérification";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Saisissez le code de vérification à 6 chiffres de votre application Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Vous avez fourni une clé Google Authenticator non valide.";
+"Enter the 6-digit verification code from your TOTP application." = "Saisissez le code de vérification à 6 chiffres de votre application TOTP.";
+"You provided an invalid TOTP key." = "Vous avez fourni une clé TOTP non valide.";
 
 "Download" = "Télécharger";
 "Language" = "Langue";

--- a/UI/MainUI/German.lproj/Localizable.strings
+++ b/UI/MainUI/German.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Sicherheitscode";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Geben Sie den 6-stelligen Sicherheitscode aus Ihrer Google Authenticator App ein.";
-"You provided an invalid Google Authenticator key." = "Sie haben einen ungültigen Google Authenticator Schlüssel eingegeben.";
+"Enter the 6-digit verification code from your TOTP application." = "Geben Sie den 6-stelligen Sicherheitscode aus Ihrer Google Authenticator App ein.";
+"You provided an invalid TOTP key." = "Sie haben einen ungültigen Google Authenticator Schlüssel eingegeben.";
 
 "Download" = "Herunterladen";
 "Language" = "Sprache";

--- a/UI/MainUI/Hungarian.lproj/Localizable.strings
+++ b/UI/MainUI/Hungarian.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Megerősítő kód";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Adja meg a Google Authenticator alkalmazás által megadott 6 jegyű megerősítő kódot.";
-"You provided an invalid Google Authenticator key." = "Érvénytelen Google Authenticator kódot adott meg.";
+"Enter the 6-digit verification code from your TOTP application." = "Adja meg a Google Authenticator alkalmazás által megadott 6 jegyű megerősítő kódot.";
+"You provided an invalid TOTP key." = "Érvénytelen Google Authenticator kódot adott meg.";
 
 "Download" = "Letöltés";
 "Language" = "Nyelv";

--- a/UI/MainUI/Polish.lproj/Localizable.strings
+++ b/UI/MainUI/Polish.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Kod weryfikacyjny";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Wpisz 6-cio cyfrowy kod z aplikacji Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Podałeś nieprawidłowy klucz Google Authenticator.";
+"Enter the 6-digit verification code from your TOTP application." = "Wpisz 6-cio cyfrowy kod z aplikacji Google Authenticator.";
+"You provided an invalid TOTP key." = "Podałeś nieprawidłowy klucz Google Authenticator.";
 
 "Download" = "Pobierz";
 "Language" = "Język";

--- a/UI/MainUI/Russian.lproj/Localizable.strings
+++ b/UI/MainUI/Russian.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Код верификации";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Введите 6-значный код подтверждения из приложения Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Вы ввели неверный ключ Google Authenticator.";
+"Enter the 6-digit verification code from your TOTP application." = "Введите 6-значный код подтверждения из приложения Google Authenticator.";
+"You provided an invalid TOTP key." = "Вы ввели неверный ключ Google Authenticator.";
 
 "Download" = "Скачать";
 "Language" = "Язык";

--- a/UI/MainUI/SOGoRootPage.m
+++ b/UI/MainUI/SOGoRootPage.m
@@ -273,7 +273,7 @@
 
               if (code != [verificationCode unsignedIntValue])
                 {
-                  [self logWithFormat: @"Invalid Google Authenticator key for '%@'", username];
+                  [self logWithFormat: @"Invalid TOTP key for '%@'", username];
                   json = [NSDictionary dictionaryWithObject: [NSNumber numberWithInt: 1]
                                                  forKey: @"GoogleAuthenticatorInvalidKey"];
                   return [self responseWithStatus: 403
@@ -282,7 +282,7 @@
             } //  if ([verificationCode length] == 6 && [verificationCode unsignedIntValue] > 0)
           else
             {
-              [self logWithFormat: @"Missing Google Authenticator key for '%@', asking it..", username];
+              [self logWithFormat: @"Missing TOTP key for '%@', asking it..", username];
               json = [NSDictionary dictionaryWithObject: [NSNumber numberWithInt: 1]
                                                  forKey: @"GoogleAuthenticatorMissingKey"];
               return [self responseWithStatus: 202

--- a/UI/MainUI/Serbian.lproj/Localizable.strings
+++ b/UI/MainUI/Serbian.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Верификациони код";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Унесите 6-цифрени код из ваше Google Authenticator апликације.";
-"You provided an invalid Google Authenticator key." = "Унели сте неисправан код.";
+"Enter the 6-digit verification code from your TOTP application." = "Унесите 6-цифрени код из ваше Google Authenticator апликације.";
+"You provided an invalid TOTP key." = "Унели сте неисправан код.";
 
 "Download" = "Преузимање";
 "Language" = "Језик";

--- a/UI/MainUI/SerbianLatin.lproj/Localizable.strings
+++ b/UI/MainUI/SerbianLatin.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Verifikacioni kod";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Unesite 6-ocifreni verifikacioni kod iz aplikacije Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Naveli ste nevažeći ključ Google Authenticator-a.";
+"Enter the 6-digit verification code from your TOTP application." = "Unesite 6-ocifreni verifikacioni kod iz aplikacije Google Authenticator.";
+"You provided an invalid TOTP key." = "Naveli ste nevažeći ključ Google Authenticator-a.";
 
 "Download" = "Preuzimanje";
 "Language" = "Jezik";

--- a/UI/MainUI/Slovak.lproj/Localizable.strings
+++ b/UI/MainUI/Slovak.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Overovací kód";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Zadajte 6-miestny číselný overovací kód z Vašej aplikácie Google Authenticator.";
-"You provided an invalid Google Authenticator key." = "Zadali ste neplatný overovací kód z Google Authenticator.";
+"Enter the 6-digit verification code from your TOTP application." = "Zadajte 6-miestny číselný overovací kód z Vašej aplikácie Google Authenticator.";
+"You provided an invalid TOTP key." = "Zadali ste neplatný overovací kód z Google Authenticator.";
 
 "Download" = "Stiahnuť";
 "Language" = "Jazyk";

--- a/UI/MainUI/Slovenian.lproj/Localizable.strings
+++ b/UI/MainUI/Slovenian.lproj/Localizable.strings
@@ -24,8 +24,8 @@
 
 /* 2FA */
 "Verification Code" = "Potrditvena koda";
-"Enter the 6-digit verification code from your Google Authenticator application." = "Vnesite 6 mestno potrditveno številko iz Google Authenticator aplikacije.";
-"You provided an invalid Google Authenticator key." = "Vnesena številka je napačna.";
+"Enter the 6-digit verification code from your TOTP application." = "Vnesite 6 mestno potrditveno številko iz Google Authenticator aplikacije.";
+"You provided an invalid TOTP key." = "Vnesena številka je napačna.";
 
 "Download" = "Prenos";
 "Language" = "Jezik";

--- a/UI/PreferencesUI/BrazilianPortuguese.lproj/Localizable.strings
+++ b/UI/PreferencesUI/BrazilianPortuguese.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Nenhum";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Ative a autenticação de dois fatores usando o Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Ative a autenticação de dois fatores usando o Google Authenticator";
+"Enable two-factor authentication using a TOTP application" = "Ative a autenticação de dois fatores usando o Google Authenticator";
+"You must enter this key into your TOTP application." = "Ative a autenticação de dois fatores usando o Google Authenticator";
 "If you do not and you log out you will not be able to login again." = "Se você não fizer isso e fizer logout, não será possível fazer o login novamente.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Catalan.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Catalan.lproj/Localizable.strings
@@ -455,8 +455,8 @@
 "animation_NONE" = "Cap";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Activa l'autenticació en dos passos mitjançant Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Has d'introduir aquesta clau a l'aplicació Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Activa l'autenticació en dos passos mitjançant Google Authenticator";
+"You must enter this key into your TOTP application." = "Has d'introduir aquesta clau a l'aplicació Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Si no ho fas i surts, no podràs tornar a iniciar la sessió.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Czech.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Czech.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Žádná";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Povolit 2-fázové ověřování pomocí Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Tento klíč musíte zadat do své aplikace Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Povolit 2-fázové ověřování pomocí Google Authenticator";
+"You must enter this key into your TOTP application." = "Tento klíč musíte zadat do své aplikace Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Pokud tak neučiníte a odhlásíte se, nebudete se moci znovu přihlásit.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/English.lproj/Localizable.strings
+++ b/UI/PreferencesUI/English.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "None";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Enable two-factor authentication using Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "You must enter this key into your Google Authenticator application.";
+"Enable two-factor authentication using a TOTP application" = "Enable two-factor authentication using a TOTP application";
+"You must enter this key into your TOTP application." = "You must enter this key into your TOTP application.";
 "If you do not and you log out you will not be able to login again." = "If you do not and you log out you will not be able to login again.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/French.lproj/Localizable.strings
+++ b/UI/PreferencesUI/French.lproj/Localizable.strings
@@ -455,8 +455,8 @@
 "animation_NONE" = "Aucun";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Activer l'authentification à deux facteurs à l'aide de Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Vous devez saisir cette clé dans votre application Google Authenticator.";
+"Enable two-factor authentication using a TOTP application = "Activer l'authentification à deux facteurs à l'aide d’une application TOTP";
+"You must enter this key into your TOTP application." = "Vous devez saisir cette clé dans votre application TOTP.";
 "If you do not and you log out you will not be able to login again." = "À défaut de le faire, vous ne pourrez pas vous reconnecter.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/German.lproj/Localizable.strings
+++ b/UI/PreferencesUI/German.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Keine";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Zwei-Faktor-Authentifizierung mit Google Authenticator aktivieren";
-"You must enter this key into your Google Authenticator application." = "Sie müssen diesen Schlüssel in Ihrer Google Authenticator App eingeben.";
+"Enable two-factor authentication using a TOTP application" = "Zwei-Faktor-Authentifizierung mit Google Authenticator aktivieren";
+"You must enter this key into your TOTP application." = "Sie müssen diesen Schlüssel in Ihrer Google Authenticator App eingeben.";
 "If you do not and you log out you will not be able to login again." = "Wenn Sie das nicht tun und sich abmelden, können Sie sich nicht mehr anmelden.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Hungarian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Hungarian.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Nincs";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Két faktoros hitelesítés engedélyezése Google Authenticator használatával";
-"You must enter this key into your Google Authenticator application." = "Meg kell adnia ezt a kulcsot a Google Authenticator alkalmazásban.";
+"Enable two-factor authentication using a TOTP application" = "Két faktoros hitelesítés engedélyezése Google Authenticator használatával";
+"You must enter this key into your TOTP application." = "Meg kell adnia ezt a kulcsot a Google Authenticator alkalmazásban.";
 "If you do not and you log out you will not be able to login again." = "Ha nem teszi meg és kijelentkezik, akkor nem lesz képes újra bejelentkezni.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Polish.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Polish.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Bez animacji";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Włącz dwuskładnikowe uwierzytelnianie przez Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Musisz wpisać ten klucz w aplikacji Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Włącz dwuskładnikowe uwierzytelnianie przez Google Authenticator";
+"You must enter this key into your TOTP application." = "Musisz wpisać ten klucz w aplikacji Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Jeśli tego nie zrobisz i wylogujesz się, nie będziesz w stanie ponownie się zalogować.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Russian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Russian.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Выключена";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Включить двухфакторную аутентификацию с помощью Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Вы должны ввести этот ключ в приложение Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Включить двухфакторную аутентификацию с помощью Google Authenticator";
+"You must enter this key into your TOTP application." = "Вы должны ввести этот ключ в приложение Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Если вы этого не сделаете и выйдете из системы, вы не сможете войти снова.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Serbian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Serbian.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Нема";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Омогући двоструку аутентикацију уз помоћ Google Authenticator апликације";
-"You must enter this key into your Google Authenticator application." = "Морате унети овај кључ у вашу Google Authenticator апликацију.";
+"Enable two-factor authentication using a TOTP application" = "Омогући двоструку аутентикацију уз помоћ Google Authenticator апликације";
+"You must enter this key into your TOTP application." = "Морате унети овај кључ у вашу Google Authenticator апликацију.";
 "If you do not and you log out you will not be able to login again." = "Уколико то не урадите и изађете из апликације, нећете моћи да се вратите накнадно.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/SerbianLatin.lproj/Localizable.strings
+++ b/UI/PreferencesUI/SerbianLatin.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Nijedan";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Omogućite dvofaktorsku potvrdu identiteta pomoću Google Authenticator-a";
-"You must enter this key into your Google Authenticator application." = "Ovaj ključ morate da unesete u aplikaciju Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Omogućite dvofaktorsku potvrdu identiteta pomoću Google Authenticator-a";
+"You must enter this key into your TOTP application." = "Ovaj ključ morate da unesete u aplikaciju Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Ako to ne učinite i odjavite se, više nećete moći da se prijavite.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Slovak.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Slovak.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Žiadna";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Povoliť 2-fázové overovanie pomocou Google Authenticator";
-"You must enter this key into your Google Authenticator application." = "Tento kľúč musíte zadať do svojej aplikácie Google Authenticator.";
+"Enable two-factor authentication using a TOTP application" = "Povoliť 2-fázové overovanie pomocou Google Authenticator";
+"You must enter this key into your TOTP application." = "Tento kľúč musíte zadať do svojej aplikácie Google Authenticator.";
 "If you do not and you log out you will not be able to login again." = "Pokiaľ tak neurobíte a odhlásíte sa, nebudete sa môcť znova prihlásiť.";
 
 /* External Sieve scripts */

--- a/UI/PreferencesUI/Slovenian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Slovenian.lproj/Localizable.strings
@@ -459,8 +459,8 @@
 "animation_NONE" = "Nobena";
 
 /* 2FA */
-"Enable two-factor authentication using Google Authenticator" = "Omogoči dvojno stopnjo prijave z uporabo Google Authenticator aplikacije";
-"You must enter this key into your Google Authenticator application." = "Prosimo, da prikazan ključ vnesete v vašo Google Authenticator aplikacijo.";
+"Enable two-factor authentication using a TOTP application" = "Omogoči dvojno stopnjo prijave z uporabo Google Authenticator aplikacije";
+"You must enter this key into your TOTP application." = "Prosimo, da prikazan ključ vnesete v vašo Google Authenticator aplikacijo.";
 "If you do not and you log out you will not be able to login again." = "Če ne, se ob naslednji prijavi ne boste uspeli vpisati.";
 
 /* External Sieve scripts */

--- a/UI/Templates/MainUI/SOGoRootPage.wox
+++ b/UI/Templates/MainUI/SOGoRootPage.wox
@@ -126,7 +126,7 @@
               </div>
             </div>
 
-            <!-- Google Authenticator Code -->
+            <!-- TOTP Code -->
             <var:if condition="isGoogleAuthenticatorEnabled">
             <div layout="row" layout-align="center center" layout-fill="layout-fill"
                  ng-switch-when="googleauthenticatorcode">
@@ -135,7 +135,7 @@
                   <label><var:string label:value="Verification Code"/></label>
                   <md-icon>lock</md-icon>
                   <input type="text" ng-pattern="app.verificationCodePattern" ng-model="app.creds.verificationCode" ng-required="app.loginState == 'googleauthenticatorcode'"/>
-                  <div class="sg-hint"><var:string label:value="Enter the 6-digit verification code from your Google Authenticator application."/></div>
+                  <div class="sg-hint"><var:string label:value="Enter the 6-digit verification code from your TOTP application."/></div>
                 </md-input-container>
                 <div layout="row" layout-align="space-between center">
                   <md-button class="md-icon-button"

--- a/UI/Templates/PreferencesUI/UIxPreferences.wox
+++ b/UI/Templates/PreferencesUI/UIxPreferences.wox
@@ -247,8 +247,8 @@
               <md-checkbox ng-model="app.preferences.defaults.SOGoGoogleAuthenticatorEnabled"
                            ng-true-value="1"
                            ng-false-value="0"
-                           label:aria-label="Enable two-factor authentication using Google Authenticator">
-                <var:string label:value="Enable two-factor authentication using Google Authenticator"/>
+                           label:aria-label="Enable two-factor authentication using a TOTP application">
+                <var:string label:value="Enable two-factor authentication using a TOTP application"/>
               </md-checkbox>
               <div layout="row" layout-align="start center" layout-xs="column"
                    layout-padding="layout-padding" layout-margin="layout-margin"
@@ -257,7 +257,7 @@
                   <sg-qr-code var:text="googleAuthenticatorKey" />
                 </div>
                 <div flex="100" flex-sm="60" flex-gt-sm="50">
-                  <var:string label:value="You must enter this key into your Google Authenticator application."/> <b><var:string label:value="If you do not and you log out you will not be able to login again."/></b>
+                  <var:string label:value="You must enter this key into your TOTP application."/> <b><var:string label:value="If you do not and you log out you will not be able to login again."/></b>
                 </div>
               </div>
             </var:if>

--- a/UI/WebServerResources/js/Common/Authentication.service.js
+++ b/UI/WebServerResources/js/Common/Authentication.service.js
@@ -93,7 +93,7 @@
               d.reject({error: l('cookiesNotEnabled')});
             }
             else {
-              // Check for Google Authenticator 2FA
+              // Check for TOTP
               if (typeof data.GoogleAuthenticatorMissingKey != 'undefined' && response.status == 202) {
                 d.resolve({gamissingkey: 1});
               }
@@ -126,7 +126,7 @@
           }, function(error) {
             var response, perr, data = error.data;
             if (data && data.GoogleAuthenticatorInvalidKey) {
-              response = {error: l('You provided an invalid Google Authenticator key.')};
+              response = {error: l('You provided an invalid TOTP key.')};
             }
             else if (data && angular.isDefined(data.LDAPPasswordPolicyError)) {
               perr = data.LDAPPasswordPolicyError;


### PR DESCRIPTION
The current codebase refers to "Google Authenticator" for TOTP, which is actually not specific to Google at all. TOTP is defined in an IETF [RFC](https://datatracker.ietf.org/doc/html/rfc6238) and implemented in many other applications, e.g. 1Password, Bitwarden, Authy, etc. I therefore suggest using more general vocabulary.

I did not update the translations, except for the English and French ones, because translators are more likely to do it correctly.

Mantis ticket: [5294](https://www.sogo.nu/bugs/view.php?id=5294).