### PR TITLE
Update SOGoInstallationGuide.asciidoc

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1757,7 +1757,8 @@ Defaults to `YES` when unset.
 
 |ModulesConstraints (optional)
 |Limits the access of any module through a constraint based on a SQL
-column; must be a dictionary with keys `Mail`, and/or `Calendar`,
+column whose value is a string (e.g. char or varchat column type);
+must be a dictionary with keys `Mail`, and/or `Calendar`,
 and/or `ActiveSync` for example:
 
 ----

--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -1757,7 +1757,7 @@ Defaults to `YES` when unset.
 
 |ModulesConstraints (optional)
 |Limits the access of any module through a constraint based on a SQL
-column whose value is a string (e.g. char or varchat column type);
+column whose value is a string (e.g. `char` or `varchar` column type);
 must be a dictionary with keys `Mail`, and/or `Calendar`,
 and/or `ActiveSync` for example:
 


### PR DESCRIPTION
Mention the value of SQL column used in `ModulesConstraints` must be a string.

We recently enabled this parameter, and used SQL column type `TINYINT(1)` (defaults to `1` which means enabled), but sogo failed to start due to error below, switched to string format (`CHAR(1)`, defaults to `y`) fixes the issue. So better mention required column type in the doc.

> 2021-09-01 00:47:49.980 sogod[1469:1469] EXCEPTION: <NSException: 0x55910887aac0> NAME:NSInvalidArgumentException REASON:NSIntNumber(instance) does not recognize caseInsensitiveMatches: INFO:(null)