### PR TITLE
ActiveSync: Fixing proxy authentication in _sendMail

### DIFF
--- a/ActiveSync/SOGoActiveSyncDispatcher.m
+++ b/ActiveSync/SOGoActiveSyncDispatcher.m
@@ -3353,7 +3353,7 @@ void handle_eas_terminate(int signum)
   NSException *error;
   NSString *from;
 
-  authenticator = [SOGoDAVAuthenticator sharedSOGoDAVAuthenticator];
+  authenticator = [[context activeUser] authenticatorInContext: context];
   dd = [[context activeUser] domainDefaults];
   
   // We generate the Sender


### PR DESCRIPTION
This is a fix for sending mails with ActiveSync when proxy authentication is being used. No other operations are affected they already work well.

While all other operations select the `SOGoAuthenticator` with `authenticatorInContext`, the method to send mail (`_sendMail` in `SOGoActiveSyncDispatcher`) is the only case where the authenticator is not selected but was hardcoded as `sharedSOGoDAVAuthenticator` and this causes a failure with proxy authentication.

Once the fix is applied all operations work fine with proxy authentication including mail sending. Note: I've verified it locally as part of PR mailcow/mailcow-dockerized#4296.