### PR TITLE
fix: custom field creation

### DIFF
--- a/UI/WebServerResources/js/Contacts/CardController.js
+++ b/UI/WebServerResources/js/Contacts/CardController.js
@@ -103,7 +103,7 @@
     };
 
     this.canAddCustomField = function () {
-      return _.keys(this.customFields).length < 4;
+      return _.keys(this.card.customFields).length < 4;
     };
 
     this.addCustomField = function () {
@@ -111,7 +111,7 @@
         this.card.customFields = {};
 
       // Find the first 'available' custom field
-      var availableKeys = _.pullAll(['1', '2', '3', '4'], _.keys(this.customFields));
+      var availableKeys = _.pullAll(['1', '2', '3', '4'], _.keys(this.card.customFields));
       this.card.customFields[availableKeys[0]] = "";
     };
 


### PR DESCRIPTION
availableKeys will always be an array containing ["1", "2", "3", "4"]
because currently the wrong customFields is not accessed correctly.

This leads to the removal of CUSTOM1 if you wanna add a second custom
field.