### PR TITLE
SOGo makes all URLs in email body lowercase - let's not do that

### DIFF
--- a/UI/MailPartViewers/UIxMailPartHTMLViewer.m
+++ b/UI/MailPartViewers/UIxMailPartHTMLViewer.m
@@ -446,7 +446,7 @@ _xmlCharsetForCharset (NSString *charset)
            attributes: (id <SaxAttributes>) _attributes
 {
   unsigned int count, max;
-  NSString *name, *value, *cid, *lowerName;
+  NSString *name, *value, *cid, *lowerName, *lowerValue;
   NSMutableString *resultPart;
   BOOL skipAttribute;
 
@@ -518,11 +518,12 @@ _xmlCharsetForCharset (NSString *charset)
                        || [name isEqualToString: @"action"]
                        || [name isEqualToString: @"formaction"])
                 {
-                  value = [[_attributes valueAtIndex: count] lowercaseString];
-                  skipAttribute = ([value rangeOfString: @"://"].location == NSNotFound
-                                   && ![value hasPrefix: @"mailto:"]
-                                   && ![value hasPrefix: @"#"]) ||
-                    [value hasPrefix: @"javascript:"];
+                  value = [_attributes valueAtIndex: count];
+                  lowerValue = [value lowercaseString];
+                  skipAttribute = ([lowerValue rangeOfString: @"://"].location == NSNotFound
+                                   && ![lowerValue hasPrefix: @"mailto:"]
+                                   && ![lowerValue hasPrefix: @"#"]) ||
+                    [lowerValue hasPrefix: @"javascript:"];
                   if (!skipAttribute)
                     [resultPart appendString: @" rel=\"noopener\""];
                 }


### PR DESCRIPTION
Hello, 
due to this commit: https://github.com/inverse-inc/sogo/blame/841dc683b54ea74f770c65604d0e654d68b6d7f0/UI/MailPartViewers/UIxMailPartHTMLViewer.m#L521

SOGo made all urls lowercase, which obviously made some links non-functional. I think lowercase was needed to properly check for `"javascipt:"` and it was not intended to modify the actual url value.

I've tried to follow code conventions as I perceived them. However, I don't know objective-c at all, so please feel free to reject this pull request and implement a better solution.

Best regards
Filip Paczyński