### PR TITLE
update documentation to add ytnef to exclude section in epel.repo

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -236,7 +236,7 @@ For RHEL/CentOS 8
 yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 ----
 
-SOGo relies on the GNUstep packages provided by Inverse and must not use the
+SOGo relies on the GNUstep and ytnef packages provided by Inverse and must not use the
 packages from EPEL. Adjust the repository definition to exclude those packages:
 
 ----

--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -241,7 +241,7 @@ packages from EPEL. Adjust the repository definition to exclude those packages:
 
 ----
 sed -i '/enabled=1/a \
-  exclude=gnustep*' /etc/yum.repos.d/epel.repo
+  exclude=gnustep* ytnef*' /etc/yum.repos.d/epel.repo
 ----
 
 For more information on EPEL, visit http://fedoraproject.org/wiki/EPEL/.


### PR DESCRIPTION
i updated the documentation towards excluding ytnef package from epel too, as we run in an issue with the ytnef package installed from epel so sogo couldn't show tnef encoded mails and was loading forever.