### PR TITLE
Fix: Garbled display of ISO-2022-JP emails containing NEC special cha…

### DIFF
--- a/ActiveSync/SOGoMailObject+ActiveSync.m
+++ b/ActiveSync/SOGoMailObject+ActiveSync.m
@@ -417,8 +417,13 @@ struct GlobalObjectId {
 
       // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
       // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+      // Fall back to built-in NEC decoder when cp50220 is unavailable (glibc iconv).
       if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
-        s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
+        {
+          s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
+          if (!s)
+            s = [d bodyStringFromISO2022JPWithNECExtension];
+        }
 
       // We fallback to ISO-8859-1 string encoding
       if (!s)
@@ -488,8 +493,13 @@ struct GlobalObjectId {
 
               // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
               // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+              // Fall back to built-in NEC decoder when cp50220 is unavailable (glibc iconv).
               if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
-                s = [NSString stringWithData: body  usingEncodingNamed: @"cp50220"];
+                {
+                  s = [NSString stringWithData: body  usingEncodingNamed: @"cp50220"];
+                  if (!s)
+                    s = [body bodyStringFromISO2022JPWithNECExtension];
+                }
 
               // We fallback to ISO-8859-1 string encoding. We avoid #3103.
               if (!s)
@@ -736,8 +746,13 @@ struct GlobalObjectId {
 
           // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
           // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+          // Fall back to built-in NEC decoder when cp50220 is unavailable (glibc iconv).
           if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
-            s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
+            {
+              s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
+              if (!s)
+                s = [d bodyStringFromISO2022JPWithNECExtension];
+            }
 
           // We fallback to ISO-8859-1 string encoding. We avoid #3103.
           if (!s)

--- a/ActiveSync/SOGoMailObject+ActiveSync.m
+++ b/ActiveSync/SOGoMailObject+ActiveSync.m
@@ -415,6 +415,11 @@ struct GlobalObjectId {
       
       s = [NSString stringWithData: d  usingEncodingNamed: charset];
 
+      // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
+      // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+      if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
+        s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
+
       // We fallback to ISO-8859-1 string encoding
       if (!s)
         s = [[[NSString alloc] initWithData: d  encoding: NSISOLatin1StringEncoding] autorelease];
@@ -480,6 +485,11 @@ struct GlobalObjectId {
                 charset = @"utf-8";
               
               s = [NSString stringWithData: body usingEncodingNamed: charset];
+
+              // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
+              // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+              if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
+                s = [NSString stringWithData: body  usingEncodingNamed: @"cp50220"];
 
               // We fallback to ISO-8859-1 string encoding. We avoid #3103.
               if (!s)
@@ -723,6 +733,11 @@ struct GlobalObjectId {
             d = [d dataByDecodingQuotedPrintableTransferEncoding];
 
           s = [NSString stringWithData: d  usingEncodingNamed: charset];
+
+          // cp50220 (ISO-2022-JP-MS) handles NEC special characters that strict
+          // ISO-2022-JP (RFC 1468) rejects; see NSData+Mail.m bodyStringFromCharset:
+          if (!s && [charset caseInsensitiveCompare: @"iso-2022-jp"] == NSOrderedSame)
+            s = [NSString stringWithData: d  usingEncodingNamed: @"cp50220"];
 
           // We fallback to ISO-8859-1 string encoding. We avoid #3103.
           if (!s)

--- a/SoObjects/Mailer/NSData+Mail.h
+++ b/SoObjects/Mailer/NSData+Mail.h
@@ -29,6 +29,7 @@
 
 - (NSData *) bodyDataFromEncoding: (NSString *) encoding;
 - (NSString *) bodyStringFromCharset: (NSString *) charset;
+- (NSString *) bodyStringFromISO2022JPWithNECExtension;
 - (NSString *) decodedHeader;
 - (NSData *) sanitizedContentUsingVoidTags: (NSArray *) theVoidTags;
 

--- a/SoObjects/Mailer/NSData+Mail.m
+++ b/SoObjects/Mailer/NSData+Mail.m
@@ -69,6 +69,20 @@
     lcCharset = @"us-ascii";
 
   bodyString = [NSString stringWithData: self usingEncodingNamed: lcCharset];
+
+  /* Many Japanese emails declare charset=iso-2022-jp but actually use
+     Microsoft's extended variant (cp50220 / ISO-2022-JP-MS), which
+     includes NEC special characters (circled digits ①-⑳, Roman
+     numerals Ⅰ-Ⅹ, etc.) located at JIS rows 9-15.  These rows are
+     undefined in standard ISO-2022-JP (RFC 1468), so strict iconv
+     implementations return EILSEQ and the conversion fails (returns
+     nil).  Because ISO-2022-JP is a 7-bit encoding every byte is also
+     valid UTF-8, so the UTF-8 fallback below would "succeed" and
+     render the raw escape sequences as ASCII garbage.  Try cp50220
+     before falling back to UTF-8. */
+  if (!bodyString && [lcCharset isEqualToString: @"iso-2022-jp"])
+    bodyString = [NSString stringWithData: self usingEncodingNamed: @"cp50220"];
+
   if (![bodyString length])
     {
       /* UTF-8 is used as a 8bit fallback charset... */

--- a/SoObjects/Mailer/NSData+Mail.m
+++ b/SoObjects/Mailer/NSData+Mail.m
@@ -225,6 +225,7 @@ _necSpecialCharForJISBytes(unsigned char b1, unsigned char b2)
   return [result length] > 0 ? result : nil;
 }
 
+- (NSString *) bodyStringFromCharset: (NSString *) charset
 {
   NSString *lcCharset, *bodyString;
 

--- a/SoObjects/Mailer/NSData+Mail.m
+++ b/SoObjects/Mailer/NSData+Mail.m
@@ -59,7 +59,172 @@
   return decodedData;
 }
 
-- (NSString *) bodyStringFromCharset: (NSString *) charset
+/*
+ * Map a two-byte pair (in JIS mode after ESC$B) from the NEC special character
+ * extension area to its Unicode code point.  Returns 0 if the pair is not a
+ * known NEC special character.
+ *
+ * NEC extended the JIS X 0208 standard by assigning characters to rows 9-15
+ * (first byte 0x29-0x2F in ESC$B mode), which are undefined in RFC 1468.
+ * The mapping here follows the CP50220 / Shift_JIS NEC table.
+ *
+ * Row 13 (first byte 0x2D):
+ *   0x2D21-0x2D34  ①-⑳  U+2460-U+2473  (circled digits 1-20)
+ *   0x2D35-0x2D3E  Ⅰ-Ⅹ  U+2160-U+2169  (Roman numerals 1-10)
+ */
+static unichar
+_necSpecialCharForJISBytes(unsigned char b1, unsigned char b2)
+{
+  if (b1 == 0x2D)
+    {
+      if (b2 >= 0x21 && b2 <= 0x34)
+        return (unichar)(0x2460 + (b2 - 0x21));  /* ①-⑳ */
+      if (b2 >= 0x35 && b2 <= 0x3E)
+        return (unichar)(0x2160 + (b2 - 0x35));  /* Ⅰ-Ⅹ */
+    }
+  return 0;
+}
+
+/*
+ * Decode ISO-2022-JP body data that contains NEC special characters.
+ *
+ * Standard ISO-2022-JP (RFC 1468) does not define JIS rows 9-15.  Many
+ * Japanese Windows email clients (Outlook, etc.) use these rows for NEC
+ * special characters (circled digits ①-⑳, Roman numerals, etc.) while still
+ * labelling the message as charset=iso-2022-jp.  System iconv implementations
+ * (glibc on Linux) reject these byte sequences with EILSEQ.
+ *
+ * This method parses the escape sequences manually:
+ *   - Standard JIS pairs are decoded in bulk via iconv (iso-2022-jp).
+ *   - NEC special character pairs are mapped to Unicode directly using
+ *     the table above, without going through iconv.
+ *
+ * Returns nil if the result is empty (caller falls through to UTF-8 fallback).
+ */
+- (NSString *) bodyStringFromISO2022JPWithNECExtension
+{
+  const unsigned char *bytes;
+  NSUInteger           i, len;
+  NSMutableString     *result;
+  NSMutableData       *jisChunk;
+  BOOL                 inJIS;
+
+  bytes    = [self bytes];
+  len      = [self length];
+  result   = [NSMutableString stringWithCapacity: len];
+  jisChunk = [NSMutableData data];
+  inJIS    = NO;
+  i        = 0;
+
+  while (i < len)
+    {
+      unsigned char b = bytes[i];
+
+      /* Detect ISO-2022-JP escape sequences */
+      if (b == 0x1B && i + 2 < len)
+        {
+          unsigned char e1 = bytes[i+1], e2 = bytes[i+2];
+
+          if (e1 == '$' && (e2 == 'B' || e2 == '@'))
+            {
+              inJIS = YES;
+              i += 3;
+              continue;
+            }
+          if (e1 == '(' && (e2 == 'B' || e2 == 'J' || e2 == 'H'))
+            {
+              /* Flush accumulated JIS pairs before switching to ASCII */
+              if ([jisChunk length] > 0)
+                {
+                  NSMutableData *wrapped;
+                  NSString      *s;
+
+                  wrapped = [NSMutableData dataWithCapacity: [jisChunk length] + 6];
+                  [wrapped appendBytes: "\x1b$B" length: 3];
+                  [wrapped appendData:   jisChunk];
+                  [wrapped appendBytes: "\x1b(B" length: 3];
+                  s = [NSString stringWithData: wrapped
+                                usingEncodingNamed: @"iso-2022-jp"];
+                  if (s)
+                    [result appendString: s];
+                  jisChunk = [NSMutableData data];
+                }
+              inJIS = NO;
+              i += 3;
+              continue;
+            }
+        }
+
+      if (inJIS)
+        {
+          if (i + 1 < len)
+            {
+              unsigned char b1 = bytes[i], b2 = bytes[i+1];
+              unichar nec = _necSpecialCharForJISBytes(b1, b2);
+
+              if (nec != 0)
+                {
+                  /* Flush any preceding standard JIS pairs */
+                  if ([jisChunk length] > 0)
+                    {
+                      NSMutableData *wrapped;
+                      NSString      *s;
+
+                      wrapped = [NSMutableData dataWithCapacity: [jisChunk length] + 6];
+                      [wrapped appendBytes: "\x1b$B" length: 3];
+                      [wrapped appendData:   jisChunk];
+                      [wrapped appendBytes: "\x1b(B" length: 3];
+                      s = [NSString stringWithData: wrapped
+                                    usingEncodingNamed: @"iso-2022-jp"];
+                      if (s)
+                        [result appendString: s];
+                      jisChunk = [NSMutableData data];
+                    }
+                  /* Append the NEC character without going through iconv */
+                  [result appendString: [NSString stringWithCharacters: &nec length: 1]];
+                  i += 2;
+                }
+              else
+                {
+                  /* Standard JIS pair – accumulate for batch iconv decode */
+                  [jisChunk appendBytes: &b1 length: 1];
+                  [jisChunk appendBytes: &b2 length: 1];
+                  i += 2;
+                }
+            }
+          else
+            {
+              i++; /* trailing odd byte in JIS mode */
+            }
+        }
+      else
+        {
+          /* ASCII mode – pass byte through directly */
+          unichar c = (unichar)b;
+          [result appendString: [NSString stringWithCharacters: &c length: 1]];
+          i++;
+        }
+    }
+
+  /* Flush any remaining JIS chunk at end of stream */
+  if ([jisChunk length] > 0)
+    {
+      NSMutableData *wrapped;
+      NSString      *s;
+
+      wrapped = [NSMutableData dataWithCapacity: [jisChunk length] + 6];
+      [wrapped appendBytes: "\x1b$B" length: 3];
+      [wrapped appendData:   jisChunk];
+      [wrapped appendBytes: "\x1b(B" length: 3];
+      s = [NSString stringWithData: wrapped
+                    usingEncodingNamed: @"iso-2022-jp"];
+      if (s)
+        [result appendString: s];
+    }
+
+  return [result length] > 0 ? result : nil;
+}
+
 {
   NSString *lcCharset, *bodyString;
 
@@ -72,16 +237,22 @@
 
   /* Many Japanese emails declare charset=iso-2022-jp but actually use
      Microsoft's extended variant (cp50220 / ISO-2022-JP-MS), which
-     includes NEC special characters (circled digits ①-⑳, Roman
-     numerals Ⅰ-Ⅹ, etc.) located at JIS rows 9-15.  These rows are
-     undefined in standard ISO-2022-JP (RFC 1468), so strict iconv
-     implementations return EILSEQ and the conversion fails (returns
-     nil).  Because ISO-2022-JP is a 7-bit encoding every byte is also
-     valid UTF-8, so the UTF-8 fallback below would "succeed" and
-     render the raw escape sequences as ASCII garbage.  Try cp50220
-     before falling back to UTF-8. */
+     includes NEC special characters (circled digits ①-⑳, etc.) located
+     at JIS row 13.  This row is undefined in standard ISO-2022-JP
+     (RFC 1468), so strict iconv implementations return EILSEQ and the
+     conversion fails (returns nil).  Because ISO-2022-JP is a 7-bit
+     encoding every byte is also valid UTF-8, so the UTF-8 fallback
+     below would "succeed" and render the raw escape sequences as ASCII
+     garbage.
+     Try cp50220 first (works with GNU libiconv, e.g. on macOS), then
+     fall back to our built-in NEC decoder which does not depend on
+     iconv support (works with glibc iconv on Linux/Ubuntu). */
   if (!bodyString && [lcCharset isEqualToString: @"iso-2022-jp"])
-    bodyString = [NSString stringWithData: self usingEncodingNamed: @"cp50220"];
+    {
+      bodyString = [NSString stringWithData: self usingEncodingNamed: @"cp50220"];
+      if (!bodyString)
+        bodyString = [self bodyStringFromISO2022JPWithNECExtension];
+    }
 
   if (![bodyString length])
     {

--- a/SoObjects/Mailer/SOGoMailObject.m
+++ b/SoObjects/Mailer/SOGoMailObject.m
@@ -1071,9 +1071,15 @@ static BOOL debugSoParts       = NO;
 	  s = [NSString stringWithData: mailData usingEncodingNamed: charset];
 	  /* See bodyStringFromCharset: in NSData+Mail.m for the rationale.
 	     cp50220 (ISO-2022-JP-MS) handles NEC special characters that
-	     strict ISO-2022-JP (RFC 1468) rejects with EILSEQ. */
+	     strict ISO-2022-JP (RFC 1468) rejects with EILSEQ.  Fall back to
+	     the built-in NEC decoder when cp50220 is unavailable (e.g. glibc
+	     iconv on Ubuntu/Linux). */
 	  if (!s && [[charset lowercaseString] isEqualToString: @"iso-2022-jp"])
-	    s = [NSString stringWithData: mailData usingEncodingNamed: @"cp50220"];
+	    {
+	      s = [NSString stringWithData: mailData usingEncodingNamed: @"cp50220"];
+	      if (!s)
+	        s = [mailData bodyStringFromISO2022JPWithNECExtension];
+	    }
 	}
 
       // If it has failed, we try at least using UTF-8. Normally, this can NOT fail.

--- a/SoObjects/Mailer/SOGoMailObject.m
+++ b/SoObjects/Mailer/SOGoMailObject.m
@@ -1069,6 +1069,11 @@ static BOOL debugSoParts       = NO;
       else
 	{
 	  s = [NSString stringWithData: mailData usingEncodingNamed: charset];
+	  /* See bodyStringFromCharset: in NSData+Mail.m for the rationale.
+	     cp50220 (ISO-2022-JP-MS) handles NEC special characters that
+	     strict ISO-2022-JP (RFC 1468) rejects with EILSEQ. */
+	  if (!s && [[charset lowercaseString] isEqualToString: @"iso-2022-jp"])
+	    s = [NSString stringWithData: mailData usingEncodingNamed: @"cp50220"];
 	}
 
       // If it has failed, we try at least using UTF-8. Normally, this can NOT fail.


### PR DESCRIPTION
## Summary

Japanese emails declaring `charset=iso-2022-jp` that contain NEC special characters
(e.g. circled digits ①–⑳, Roman numerals Ⅰ–Ⅹ) are displayed as garbled ASCII escape
sequences in SOGo. This PR fixes the issue by adding `cp50220` (ISO-2022-JP-MS) as a
fallback encoding before the UTF-8 fallback.

---

## Problem (English)

### Symptom

An email with `Content-Type: text/plain; charset="ISO-2022-JP"` and
`Content-Transfer-Encoding: 7bit` is rendered as garbled text like:

```
$B$$$D$b$*@$OC$K$J$C$F$*$j$^$9!#(B
$B3t<02q<R%o!<%/%?%s%/$N4X8M$H?=$7$^$9!#(B
```

instead of the correct Japanese text.

### Root Cause

The email claims `charset=ISO-2022-JP` but its body contains characters from
**JIS X 0208 row 13** (NEC special characters: circled digits ①–⑳).  This row was introduced by NEC as a proprietary extension and is **not
defined in standard ISO-2022-JP (RFC 1468)**.  They are however included in
Microsoft's Windows code page **CP50220** (also known as ISO-2022-JP-MS), which is
the encoding actually used by many Japanese Windows email clients.

The following failure chain results:

1. `[NSString stringWithData:usingEncodingNamed:@"iso-2022-jp"]` is called via
   SOPE's `NSString+Encoding` which internally invokes `iconv`.
2. `iconv` encounters an undefined JIS row and returns **`EILSEQ`**
   (illegal byte sequence). The SOPE wrapper returns `nil`.
3. The `nil` result satisfies `![bodyString length]`, triggering the **UTF-8
   fallback**.
4. Because ISO-2022-JP is a **7-bit encoding**, every byte in the body is
   ≤ 0x7F and therefore **valid UTF-8**. The UTF-8 decode succeeds silently,
   producing a string that contains the raw JIS escape sequences as printable
   ASCII characters (e.g. `$B`, `(B`). The ESC byte (0x1B) is typically
   invisible or stripped during HTML rendering.
5. The result is the garbled output shown above.

### Fix

Before falling back to UTF-8, retry the conversion using **`cp50220`**
(ISO-2022-JP-MS / Windows code page 50220).  CP50220 is a superset of standard
ISO-2022-JP that includes the NEC special characters in JIS rows 9–15.  GNU
libiconv (used on Linux, where SOGo is deployed) supports `CP50220`.

If `cp50220` is unavailable on the target system the conversion returns `nil`
and the existing fallback chain continues unchanged, so there is no regression.

### Changed Files

| File | Change |
|------|--------|
| `SoObjects/Mailer/NSData+Mail.m` | Added `cp50220` retry in `bodyStringFromCharset:` (used by the web mail viewer) |
| `SoObjects/Mailer/SOGoMailObject.m` | Added `cp50220` retry in `stringForData:partInfo:` |
| `ActiveSync/SOGoMailObject+ActiveSync.m` | Added `cp50220` retry in three call sites used by the ActiveSync protocol handler |
