### PR TITLE
fix(mail): Fix search highlight rendering for accented characters and message subject

### DIFF
--- a/UI/Templates/MailerUI/UIxMailViewTemplate.wox
+++ b/UI/Templates/MailerUI/UIxMailViewTemplate.wox
@@ -194,7 +194,7 @@
         </md-card-actions>
         <md-card-content>
           <div class="sg-padded">
-            <h5 class="sg-md-headline" ng-bind="viewer.message.subject"><!-- subject --></h5>
+            <h5 class="sg-md-headline" ng-bind-html="viewer.message.subject"><!-- subject --></h5>
             <time class="msg-date" datetime="viewer.message.date" ng-bind="::viewer.message.date"><!-- date --></time>
           </div>
           <div layout="row" layout-wrap="layout-wrap">

--- a/UI/WebServerResources/js/Mailer/Message.service.js
+++ b/UI/WebServerResources/js/Mailer/Message.service.js
@@ -525,7 +525,7 @@
         && data 
         && -1 === data.indexOf("data-markjs")) {
       var dom = document.createElement("DIV");
-      dom.textContent = encodeEntities ? data.encodeEntities() : data;
+      dom.innerHTML = encodeEntities ? data.encodeEntities() : data;
       var markInstance = new Mark(dom);
       markInstance.mark(this.$mailbox.getHighlightWords());
       data = dom.innerHTML;


### PR DESCRIPTION
## Problem

When using the search feature in the mail module, two rendering issues were found:

### 1. Accented characters displayed as HTML entities in message list
When a contact name contains accented characters (e.g. `í`, `ó`, `ñ`),
the sender name in the message list was displaying raw HTML entities
(e.g. `&#237;`) instead of the correct character.

This was caused by `dom.textContent` being used to insert the data before
Mark.js highlighted it. Using `textContent` causes the browser to treat
HTML entities as literal text, which then gets re-serialized as visible
entities when reading `dom.innerHTML`.

**Fix:** Replace `dom.textContent` with `dom.innerHTML` so HTML entities
are correctly interpreted before Mark.js processes the content.

### 2. `<mark>` tags rendered as plain text in message reading view
When opening a message from search results, the subject in the reading
view was showing the raw `<mark>` tags as plain text instead of rendering
the highlight.

This was caused by `ng-bind` being used in `UIxMailViewTemplate.wox`,
which renders content as plain text. Since `highlightSearchTerms()`
returns HTML with `<mark>` tags, it requires `ng-bind-html` to be
interpreted correctly.

**Fix:** Replace `ng-bind` with `ng-bind-html` for the subject field in
the message reading view.

## Changes

- `UI/WebServerResources/js/Mailer/Message.service.js`: Replace
  `dom.textContent` with `dom.innerHTML` in `highlightSearchTerms()`
- `UI/Templates/MailerUI/UIxMailViewTemplate.wox`: Replace `ng-bind`
  with `ng-bind-html` for `viewer.message.subject`

## Testing

- Search for a term matching a contact name with accented characters →
  name renders correctly in message list
- Open a message from search results → subject shows highlighted term
  correctly in the reading view header