### PR TITLE
usesCASAuthentication still useful for CAS-specific frontend recovery logic

### DIFF
--- a/UI/Common/UIxPageFrame.m
+++ b/UI/Common/UIxPageFrame.m
@@ -488,6 +488,14 @@
 	  && [user isSuperUser]);
 }
 
+- (BOOL) usesCASAuthentication
+{
+  SOGoSystemDefaults *sd;
+
+  sd = [SOGoSystemDefaults sharedSystemDefaults];
+
+  return [[sd authenticationType] isEqualToString: @"cas"];
+}
 
 - (BOOL) usesOpenIdAuthentication
 {


### PR DESCRIPTION
usesCASAuthentication is still referenced by the UI templates to expose the CAS mode to JavaScript.
Removing it makes pages emit usesCASAuthentication = false, breaking CAS-specific frontend recovery logic.
usesCASAuthentication has been removed in c3234882eb0dc